### PR TITLE
Macos dialog cleanup

### DIFF
--- a/src/PlatformSpecific/Desktop/Dialog/OpenFile.mac.mm
+++ b/src/PlatformSpecific/Desktop/Dialog/OpenFile.mac.mm
@@ -16,9 +16,6 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 	{
         @autoreleasepool
         {
-            [NSApplication sharedApplication]; // FIXME: Check the usefulness of this line !
-            [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
-
             NSString * title = [NSString stringWithCString:this->title().c_str()
             encoding:[NSString defaultCStringEncoding]];
 

--- a/src/PlatformSpecific/Desktop/Dialog/SaveFile.mac.mm
+++ b/src/PlatformSpecific/Desktop/Dialog/SaveFile.mac.mm
@@ -16,9 +16,6 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 	{
 		@autoreleasepool
         {
-            [NSApplication sharedApplication]; // FIXME: Check the usefulness of this line !
-            [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
-
             NSString * title = [NSString stringWithCString:this->title().c_str()
             encoding:[NSString defaultCStringEncoding]];
 


### PR DESCRIPTION
Remove redundant NSApplication initialization from macOS dialogs

The NSApplication setup and activation policy configuration were
unnecessary in OpenFile and SaveFile dialogs, as the application
is already initialized at this point.