### PR TITLE
Fix macOS dock icon disappearing when showing message dialogs

### DIFF
--- a/src/PlatformSpecific/Desktop/Dialog/CustomMessage.mac.mm
+++ b/src/PlatformSpecific/Desktop/Dialog/CustomMessage.mac.mm
@@ -46,8 +46,6 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 
 		@autoreleasepool
 		{
-			[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
-
 			NSAlert * alert = [[NSAlert alloc] init];
 
 			/* Set alert style based on message type. */

--- a/src/PlatformSpecific/Desktop/Dialog/Message.mac.mm
+++ b/src/PlatformSpecific/Desktop/Dialog/Message.mac.mm
@@ -39,8 +39,6 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 	{
         @autoreleasepool
         {
-            [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
-
             NSAlert * alert = [[NSAlert alloc] init];
 
             switch ( m_messageType )


### PR DESCRIPTION
Remove unnecessary NSApplicationActivationPolicyAccessory calls in Message and CustomMessage dialogs. This policy hid the app from the dock and was never restored. File dialogs (OpenFile, SaveFile) never needed it — CGShieldingWindowLevel is sufficient for proper layering.