### PR TITLE
Fix duplicate file extension in macOS save dialog

### DIFF
--- a/src/PlatformSpecific/Desktop/Dialog/SaveFile.mac.mm
+++ b/src/PlatformSpecific/Desktop/Dialog/SaveFile.mac.mm
@@ -49,10 +49,12 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 
             [panel setTitle:title];
 
-            /* Set default filename. */
+            /* Set default filename (strip extension since NSSavePanel adds it automatically via allowedContentTypes). */
             if ( !m_defaultFilename.empty() )
             {
-                NSString * defaultName = [NSString stringWithUTF8String:m_defaultFilename.c_str()];
+                std::filesystem::path filenamePath{m_defaultFilename};
+                const auto stem = filenamePath.stem().string();
+                NSString * defaultName = [NSString stringWithUTF8String:(!stem.empty() ? stem : m_defaultFilename).c_str()];
                 [panel setNameFieldStringValue:defaultName];
             }
 


### PR DESCRIPTION
NSSavePanel automatically appends the extension from allowedContentTypes. When the default filename already included the extension (e.g. "project.lys"), the user would see "project.lys" with macOS adding ".lys" again.

Strip the extension from the default filename before passing it to setNameFieldStringValue, letting NSSavePanel handle it via allowedContentTypes.