### PR TITLE
Only strip extension when it matches a declared filter

### DIFF
--- a/src/PlatformSpecific/Desktop/Dialog/SaveFile.mac.mm
+++ b/src/PlatformSpecific/Desktop/Dialog/SaveFile.mac.mm
@@ -49,12 +49,34 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 
             [panel setTitle:title];
 
-            /* Set default filename (strip extension since NSSavePanel adds it automatically via allowedContentTypes). */
+            /* Set default filename (strip extension only if it matches a declared filter,
+             * since NSSavePanel adds it automatically via allowedContentTypes). */
             if ( !m_defaultFilename.empty() )
             {
+                std::string nameForPanel = m_defaultFilename;
                 std::filesystem::path filenamePath{m_defaultFilename};
-                const auto stem = filenamePath.stem().string();
-                NSString * defaultName = [NSString stringWithUTF8String:(!stem.empty() ? stem : m_defaultFilename).c_str()];
+                const auto ext = filenamePath.extension().string(); // e.g. ".lys"
+
+                if ( !ext.empty() )
+                {
+                    const auto extWithoutDot = ext.substr(1); // e.g. "lys"
+
+                    for ( const auto & filter : m_extensionFilters )
+                    {
+                        for ( const auto & filterExt : filter.second )
+                        {
+                            /* Compare against both ".lys" and "lys" forms. */
+                            if ( filterExt == ext || filterExt == extWithoutDot )
+                            {
+                                nameForPanel = filenamePath.stem().string();
+                                goto done;
+                            }
+                        }
+                    }
+                }
+                done:
+
+                NSString * defaultName = [NSString stringWithUTF8String:nameForPanel.c_str()];
                 [panel setNameFieldStringValue:defaultName];
             }
 


### PR DESCRIPTION
Avoid stripping parts of the actual filename (e.g. "project.model1") by checking the extension against declared filter extensions before removing it. This ensures only known file type extensions are stripped.