### PR TITLE
enable precompiled headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,17 @@ pulled in by `cmake/InstallEmeraudeBase.cmake` (clone-if-absent + `add_subdirect
 > emeraude-base is also the **single source of truth for external dependencies**: it owns
 > every `Setup*.cmake` (even libs only the engine uses: ufbx, fastgltf, taglib, bc7enc,
 > cpu_features, hwloc, libvpx), the `ext-deps-generator` resolution (`EMERAUDE_EXT_LIBS_*`),
-> and the **project-wide compile policy** (`EMERAUDE_COMPILE_*`, `EMERAUDE_CXX_VERSION`,
-> `EMERAUDE_C_VERSION`). The engine inherits all of it via `emeraude::base` and adds
-> `EMERAUDE_BASE_CMAKE_DIR` to its module path.
+> the **project-wide compile policy** (`EMERAUDE_COMPILE_*`, `EMERAUDE_CXX_VERSION`,
+> `EMERAUDE_C_VERSION`), and the **shared STL hot-set precompiled header** (`PrecompiledHeaders.hpp`
+> + `cmake/EnablePrecompiledHeaders.cmake`). The engine inherits all of it via `emeraude::base`
+> and adds `EMERAUDE_BASE_CMAKE_DIR` to its module path.
+>
+> **Precompiled header:** the engine itself is **deliberately NOT precompiled-header'd.** It is a
+> SHARED library built with `WINDOWS_EXPORT_ALL_SYMBOLS`, and CMake's auto-generated export `.def`
+> scans the PCH object, pulling compiler-internal symbols that then fail to resolve (`LNK2001` in
+> `exports.def`). base's shared STL PCH is applied only to **leaf** targets (app_kernel's Kernel,
+> app_system's binaries — none of which export all symbols), never to the engine or to base's own
+> modules linked into it. See `dependencies/emeraude-base/AGENTS.md` § 3a.
 >
 > **Rule:** a bug or a missing feature in the foundation layer (math, factories, I/O,
 > threading, …) is fixed **in emeraude-base**, never worked around in the engine — the same

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,8 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/$<CONFIG>")
 # Emeraude libraries project variables and options.
 set(EMERAUDE_COMPILATION_DIR "" CACHE STRING "Declare where the project is compiled. For macOS this should point the 'package.app' in the compilation folder.")
 option(EMERAUDE_ENABLE_TESTS "Enable the Emeraude-Engine testing suite (Default Off)." Off)
-option(EMERAUDE_ENABLE_PCH "Enable 'PreCompiled Headers' feature to speed up the compilation (Default Off)." Off)
+# EMERAUDE_ENABLE_PCH is owned by emeraude-base (project-wide compile policy, default On) —
+# declared there and consumed via emeraude_base_target_enable_pch(). Not re-declared here.
 option(EMERAUDE_USE_STATIC_RUNTIME "Build Emeraude-Engine with the static MSVC runtime (Windows only, Default Off)." Off)
 option(EMERAUDE_USE_SYSTEM_LIBS "Use the system for common libraries instead of the embedded ones (Deprecated, Default Off)." Off)
 option(EMERAUDE_USE_SYSTEM_OPENAL "Use the system OpenAL-Soft library (Default Off)." Off)
@@ -207,10 +208,11 @@ add_library(${PROJECT_NAME} SHARED ${EMERAUDE_SOURCE_FILES})
 
 target_sources(${PROJECT_NAME} PUBLIC FILE_SET HEADERS BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src FILES ${EMERAUDE_HEADER_FILES})
 
-# Precompiled headers
-if ( EMERAUDE_ENABLE_PCH )
-	target_precompile_headers(${PROJECT_NAME} PUBLIC ${EMERAUDE_HEADER_FILES})
-endif ()
+# No precompiled header on the engine. It is a SHARED library built with
+# WINDOWS_EXPORT_ALL_SYMBOLS, and CMake's auto-generated export .def scans the PCH object,
+# pulling compiler-internal symbols that then fail to resolve (LNK2001 in exports.def). The
+# shared STL PCH owned by emeraude-base is therefore applied only to LEAF targets — app_kernel's
+# Kernel and app_system's binaries — never to the engine or to base's own modules linked into it.
 
 target_link_directories(${PROJECT_NAME} PUBLIC ${EMERAUDE_EXT_LIBS_LIB_DIR})
 


### PR DESCRIPTION
Remove dormant PCH block (engine stays un-PCH'd)

**Problème**

Le bloc PCH existant précompilait tous les en-têtes de l'engine en PUBLIC : invalidation totale à la moindre édition de header + fuite INTERFACE_PRECOMPILE_HEADERS vers les consommateurs (app_system). Il était dormant (EMERAUDE_ENABLE_PCH défaut Off).

**Solution**

Suppression de ce bloc et de l'option EMERAUDE_ENABLE_PCH redéclarée localement (désormais possédée par emeraude-base). L'engine n'est volontairement pas precompiled-header'd : c'est une SHARED lib avec WINDOWS_EXPORT_ALL_SYMBOLS, et le .def d'export auto-généré scanne l'objet PCH → symboles internes non résolus (LNK2001). Le gain d'un PCH STL-only y serait de toute façon faible (le coût de l'engine est ailleurs : ses propres gros headers + Vulkan).

Doc : AGENTS.md mis à jour (pourquoi l'engine n'est pas PCH'd, base = source du header STL).