### PR TITLE
TECH-1838 fix latency for dialog boxes on windows

### DIFF
--- a/src/PlatformSpecific/AGENTS.md
+++ b/src/PlatformSpecific/AGENTS.md
@@ -220,6 +220,36 @@ See: `Dialog/SaveFile.hpp:setDefaultFilename()`, `Dialog/SaveFile.hpp:setDefault
 | Linux | kdialog positional arg / zenity `--filename=` | Same | Appended to path arg | Handled by desktop tool |
 | macOS | `NSOpenPanel setDirectoryURL:` | `NSSavePanel setDirectoryURL:` | `setNameFieldStringValue:` | Handled by `allowedContentTypes` |
 
+### Windows: native file dialogs run on a dedicated STA thread (critical)
+
+On Windows, `OpenFile::execute()` and `SaveFile::execute()` show the modern
+`IFileOpenDialog` / `IFileSaveDialog` on a **dedicated STA thread**, not on the calling
+thread. This is mandatory for performance — not stylistic.
+
+**Why:** the dialog's modal message loop pumps **every** message of the thread it runs on.
+Shown from a busy thread (the engine main loop pumping rendering, input, and — under
+app_system — CEF), the Windows shell re-resolves its navigation pane on every message
+burst: thousands of redundant known-folder / cloud-sync-root (`SyncRootManager`) registry
+lookups. On a machine whose known folders are redirected to a cloud provider (OneDrive —
+the Windows default), this delays the dialog by **3–5 s**. A dedicated thread has an empty
+message queue, so the pane is resolved once and the dialog appears in ~140 ms (measured
+×25 speed-up). Apps with an idle UI thread (e.g. Notepad++) never hit this — which is why
+the same dialog is instant elsewhere on the same machine.
+
+**Implementation:** `execute()` spawns a `std::thread` that `CoInitializeEx(STA)`s and
+re-enters `execute()` (a `thread_local` guard prevents recursion), then `join()`s. The
+owner HWND is intentionally `null` (`parentToWindow=false` on the worker): the caller
+blocks on `join()` — `execute()` is synchronous by contract — so a cross-thread owner
+window would risk a modal-pump deadlock. Trade-off: the dialog is not owned by the main
+window (harmless: the app is already blocked while it is up). See the comment block in
+`Dialog/OpenFile.windows.cpp`.
+
+> [!WARNING]
+> Do **not** "simplify" this back to a direct `Show()` on the calling thread — it silently
+> reintroduces the 3–5 s freeze on any machine with cloud-redirected known folders (i.e.
+> most Windows installs with OneDrive). The cost is invisible on a developer machine
+> without OneDrive folder redirection.
+
 ### Linux Dialog Implementation (zenity/kdialog)
 
 Linux dialogs use native desktop tools via shell commands.

--- a/src/PlatformSpecific/Desktop/Dialog/OpenFile.windows.cpp
+++ b/src/PlatformSpecific/Desktop/Dialog/OpenFile.windows.cpp
@@ -36,6 +36,7 @@
 /* STL inclusions. */
 #include <filesystem>
 #include <map>
+#include <thread>
 #include <vector>
 
 /* Third-party inclusions. */
@@ -241,6 +242,47 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 	bool
 	OpenFile::execute (Window & window, bool parentToWindow) noexcept
 	{
+		/* The native file dialog runs on a DEDICATED STA thread whose message queue is empty.
+		 *
+		 * Rationale: shown from the engine's main thread, the dialog's modal message loop pumps
+		 * the main thread's heavy message traffic (rendering, input, CEF). The Windows shell
+		 * reacts by re-resolving the navigation pane on every burst — thousands of redundant
+		 * known-folder / cloud-sync-root (SyncRootManager) registry lookups — which delays the
+		 * dialog by 3-5 s on machines whose known folders are redirected to a cloud provider
+		 * (e.g. OneDrive, the Windows default). On a dedicated thread the queue stays quiet, the
+		 * pane is resolved once, and the dialog appears in ~140 ms.
+		 *
+		 * We re-enter execute() on the worker (the thread-local guard prevents recursion) with
+		 * parentToWindow=false: the calling thread blocks on join() (execute() is synchronous by
+		 * contract), so giving the modal dialog a cross-thread owner window would risk a
+		 * message-pump deadlock. Trade-off: the dialog is not owned by the main window — harmless
+		 * here since the app is already blocked while the dialog is up. */
+		{
+			static thread_local bool onDedicatedDialogThread = false;
+
+			if ( !onDedicatedDialogThread )
+			{
+				bool result = false;
+
+				std::thread worker{[this, &window, &result] () {
+					onDedicatedDialogThread = true;
+
+					const HRESULT comInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+
+					result = this->execute(window, false);
+
+					if ( SUCCEEDED(comInit) )
+					{
+						CoUninitialize();
+					}
+				}};
+
+				worker.join();
+
+				return result;
+			}
+		}
+
 		HWND parentWindow = parentToWindow ? window.getWin32Window() : nullptr;
 
 		/* NOTE: Branch to the Win32 legacy path when the compatibility setting is enabled.

--- a/src/PlatformSpecific/Desktop/Dialog/SaveFile.windows.cpp
+++ b/src/PlatformSpecific/Desktop/Dialog/SaveFile.windows.cpp
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <map>
+#include <thread>
 #include <vector>
 
 /* Third-party inclusions. */
@@ -196,6 +197,39 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 	bool
 	SaveFile::execute (Window & window, bool parentToWindow) noexcept
 	{
+		/* The native file dialog runs on a DEDICATED STA thread whose message queue is empty.
+		 * See OpenFile::execute() for the full rationale: on the engine main thread the modal
+		 * message pump lets the Windows shell re-resolve its navigation pane thousands of times
+		 * (empty SyncRootManager / known-folder lookups), delaying the dialog by 3-5 s on
+		 * cloud-redirected-known-folder machines; a quiet thread resolves the pane once (~140 ms).
+		 * We re-enter execute() on the worker (thread-local guard prevents recursion) with
+		 * parentToWindow=false to avoid a cross-thread modal owner (the caller blocks on join()). */
+		{
+			static thread_local bool onDedicatedDialogThread = false;
+
+			if ( !onDedicatedDialogThread )
+			{
+				bool result = false;
+
+				std::thread worker{[this, &window, &result] () {
+					onDedicatedDialogThread = true;
+
+					const HRESULT comInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+
+					result = this->execute(window, false);
+
+					if ( SUCCEEDED(comInit) )
+					{
+						CoUninitialize();
+					}
+				}};
+
+				worker.join();
+
+				return result;
+			}
+		}
+
 		HWND parentWindow = parentToWindow ? window.getWin32Window() : nullptr;
 
 		/* NOTE: Branch to the Win32 legacy path when the compatibility setting is enabled.


### PR DESCRIPTION
Ticket jira : https://mango3d.atlassian.net/browse/TECH-1838

**Problème**

Sous Windows, les dialogues fichier natifs (IFileOpenDialog/IFileSaveDialog, Open Scene, Save, Open Folder) mettaient 3–5 s à s'afficher.

Le dialogue shell s'exécute in-process, sur le thread appelant (la boucle principale du moteur), et sa boucle de messages modale dépile toute la file de messages de ce thread. Or ce thread est saturé par le moteur et CEF. Étant un contrôle UI vivant (objet COM STA piloté par les messages), le volet de navigation re-valide ses items à chaque salve de messages → ~16 000 vérifications registre redondantes (IsUnderKnownFolder → SyncRootManager, vides car dossiers connus redirigés vers OneDrive) → 3–5 s de gel. Mesuré : Show() → premier affichage = ~3 500 ms.

  ▎ Écartés par la mesure : code/IPC/ZeroMQ, API COM vs legacy, sécurité COM/CEF, apartment, mitigations, churn disque, filtres/defaultPath.

**Solution**

Exécuter le dialogue natif sur un thread STA dédié à file de messages vide. La boucle modale ne dépile alors que les messages propres au dialogue → le volet est résolu une seule fois → ~140 ms (×25). Bug et fix sont entièrement côté moteur ; aucun changement dans app_system.

**Implémentation**

  - vendors/emeraude-engine/src/PlatformSpecific/Desktop/Dialog/OpenFile.windows.cpp et SaveFile.windows.cpp : execute() lance un std::thread qui CoInitializeEx(STA) puis ré-entre execute() (garde thread_local anti-récursion), et join().
  - Owner HWND = null (parentToWindow=false sur le worker) : le thread appelant étant bloqué sur join(), un owner inter-thread risquerait un deadlock de pompe modale. Compromis : le dialogue n'est pas modal-enfant de la fenêtre (sans conséquence, l'app est déjà bloquée pendant l'affichage).
  - Doc : section « Windows: native file dialogs run on a dedicated STA thread » dans PlatformSpecific/AGENTS.md (+ avertissement anti-régression : ne pas re-simplifier en Show() direct, sinon le gel revient sur toute machine OneDrive).