### PR TITLE
TECH-1838 fix file dialogbox centering on windows

### DIFF
--- a/src/PlatformSpecific/AGENTS.md
+++ b/src/PlatformSpecific/AGENTS.md
@@ -61,10 +61,12 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 ```
 PlatformSpecific/
 ├── AGENTS.md                    # This file
-├── Helpers.hpp                  # Cross-platform helper declarations
+├── Helpers.hpp                  # Cross-platform helper declarations (incl. Windows-only file-dialog
+│                                #   thread helper runFileDialogOnDedicatedThread())
 ├── Helpers.linux.cpp            # Linux helper implementations
 ├── Helpers.mac.cpp              # macOS helper implementations
-├── Helpers.windows.cpp          # Windows helper implementations
+├── Helpers.windows.cpp          # Windows helper implementations (incl. runFileDialogOnDedicatedThread()
+│                                #   + file-local CenteringOwner — dedicated STA thread + centering proxy)
 ├── SystemInfo.hpp/.cpp          # System information (+ hybrid CPU detection via hwloc)
 ├── UserInfo.hpp/.cpp            # User information (+ platform files)
 ├── Types.hpp                    # Common type definitions (CPU struct with E/P-core counts)
@@ -81,13 +83,19 @@ PlatformSpecific/
     ├── Commands.*               # System commands (taskbar, etc.)
     ├── Notification.*           # System notifications
     └── Dialog/
-        ├── Abstract.hpp         # Base class for all dialogs
-        ├── Types.hpp/.cpp       # Dialog types and aliases
-        ├── Message.*            # Message dialogs (preset buttons)
-        ├── CustomMessage.*      # Custom button dialogs
-        ├── OpenFile.*           # File/folder open dialogs
-        └── SaveFile.*           # File save dialogs
+        ├── Abstract.hpp           # Base class for all dialogs
+        ├── Types.hpp/.cpp         # Dialog types and aliases
+        ├── Message.*              # Message dialogs (preset buttons)
+        ├── CustomMessage.*        # Custom button dialogs
+        ├── OpenFile.*             # File/folder open dialogs
+        └── SaveFile.*             # File save dialogs
 ```
+
+> [!NOTE]
+> The Windows dedicated-STA-thread file-dialog helper (`runFileDialogOnDedicatedThread()`
+> + the file-local `CenteringOwner`) lives in `PlatformSpecific/Helpers.{hpp,windows.cpp}`,
+> **not** under `Desktop/Dialog/` — it is OS-machinery shared by `OpenFile`/`SaveFile`, so it
+> sits with the other Windows helpers.
 
 ### File Naming Convention
 
@@ -99,6 +107,60 @@ Platform-specific implementations use suffixes:
 | `.windows.cpp` | Windows | C++ |
 
 CMake selects the appropriate file based on target platform.
+
+---
+
+## Windows: native file dialogs run on a dedicated STA thread
+
+`OpenFile.windows.cpp` and `SaveFile.windows.cpp` do **not** show the modern COM dialog
+(`IFileOpenDialog` / `IFileSaveDialog`) on the engine's main thread. Their `execute()` is a thin
+wrapper that delegates to the shared helper `runFileDialogOnDedicatedThread()`
+(`Helpers.hpp` / `Helpers.windows.cpp`): it spawns a **dedicated STA thread** with an empty
+message queue, runs the dialog body (`OpenFile::showDialog` / `SaveFile::showDialog`) there, and
+`join()`s it. The helper owns the thread, COM init, and the centering proxy; the per-dialog
+`showDialog()` only does the COM dialog work and receives the resolved parent `HWND`. On failure
+to spawn the worker (OS resource exhaustion), it falls back to running the dialog inline on the
+caller thread.
+
+**Why (perf):** on the main thread the dialog's modal message loop pumps the heavy main-thread
+traffic (rendering, input, CEF). The Windows shell reacts by re-resolving its navigation pane on
+every burst — thousands of redundant known-folder / cloud-sync-root (`SyncRootManager`) registry
+lookups — delaying the dialog **3–5 s** on machines whose known folders are redirected to a cloud
+provider (OneDrive, the Windows default). On a quiet dedicated thread the pane resolves once and
+the dialog appears in **~140 ms**.
+
+> [!WARNING]
+> Do **not** "simplify" by calling `Show()` directly on the calling thread — it silently
+> reintroduces the 3–5 s freeze on any machine with cloud-redirected known folders (invisible on
+> a plain dev box, hence hard to diagnose).
+
+### Dialog centering — `CenteringOwner` (TECH-1838)
+
+Passing the main window as the modal dialog's owner is **not** possible here: the main window
+lives on the main thread, which is blocked on `join()` while the dialog is up, so a cross-thread
+owner risks a message-pump deadlock (the modal dialog's implicit `WM_ENABLE` / activation sends to
+the owner thread would never return). The first perf fix therefore used a **null owner** — which
+also dropped native placement (dialog no longer centered on the app window, wrong monitor in
+multi-screen). Note the lag and the owner are **independent**: the lag is purely a function of the
+thread on which `Show()` pumps messages, not of the owner — so the centering fix below does not
+reintroduce it.
+
+`runFileDialogOnDedicatedThread()` restores placement **without** a cross-thread owner:
+
+1. On the **caller thread**, before spawning the worker, it reads the main window's screen
+   rectangle (`GetWindowRect`) and DPI awareness context (`GetWindowDpiAwarenessContext`), passed
+   **by value** to the worker (no cross-thread HWND deref on the worker).
+2. On the **worker (STA) thread**, `SetThreadDpiAwarenessContext(...)` matches the main window,
+   then a `CenteringOwner` (file-local in `Helpers.windows.cpp`) is built — a hidden
+   top-level window (built-in `STATIC` class, `WS_POPUP` without `WS_VISIBLE`) positioned over that
+   rectangle. It is created **and destroyed on the worker thread** (RAII), so there is **no
+   cross-thread owner** and no deadlock risk — the owner enable/disable sends stay same-thread.
+3. The proxy `HWND` is passed to the dialog body, which feeds it to `Show(parentWindow)` and to the
+   legacy `OPENFILENAMEW.hwndOwner` / `BROWSEINFOW.hwndOwner` paths.
+
+The shell centers the dialog on the proxy natively, at creation time — **no post-show jump, no
+flash**, correct monitor in multi-screen. The proxy is never shown; the shell only needs its
+geometry.
 
 ---
 
@@ -236,13 +298,15 @@ message queue, so the pane is resolved once and the dialog appears in ~140 ms (m
 ×25 speed-up). Apps with an idle UI thread (e.g. Notepad++) never hit this — which is why
 the same dialog is instant elsewhere on the same machine.
 
-**Implementation:** `execute()` spawns a `std::thread` that `CoInitializeEx(STA)`s and
-re-enters `execute()` (a `thread_local` guard prevents recursion), then `join()`s. The
-owner HWND is intentionally `null` (`parentToWindow=false` on the worker): the caller
-blocks on `join()` — `execute()` is synchronous by contract — so a cross-thread owner
-window would risk a modal-pump deadlock. Trade-off: the dialog is not owned by the main
-window (harmless: the app is already blocked while it is up). See the comment block in
-`Dialog/OpenFile.windows.cpp`.
+**Implementation:** `execute()` delegates to `runFileDialogOnDedicatedThread()`
+(`Helpers.{hpp,windows.cpp}`), passing its COM dialog body (`showDialog()`) as a callback. The
+helper spawns a `std::thread` that `CoInitializeEx(STA)`s, builds the hidden `CenteringOwner`
+(see § Dialog centering above), runs the body, then `join()`s — the caller blocks on `join()`
+because `execute()` is synchronous by contract. The centering owner is created **on the worker
+thread** (never a cross-thread owner), which is what makes native centering possible without a
+modal-pump deadlock. If the worker thread cannot be spawned, the helper runs the dialog inline on
+the caller thread (slower on cloud-redirected machines, but functional). See the comment block in
+`Dialog/OpenFile.windows.cpp` and `Helpers.windows.cpp`.
 
 > [!WARNING]
 > Do **not** "simplify" this back to a direct `Show()` on the calling thread — it silently

--- a/src/PlatformSpecific/Desktop/Dialog/OpenFile.hpp
+++ b/src/PlatformSpecific/Desktop/Dialog/OpenFile.hpp
@@ -31,6 +31,12 @@
 #include <utility>
 #include <vector>
 
+/* Local inclusions. */
+#include "emeraude_platform.hpp"
+#if IS_WINDOWS
+	#include "PlatformSpecific/Helpers.hpp" /* Provides the Win32 HWND type for the Windows-only showDialog(). */
+#endif
+
 /* Local inclusions for inheritances. */
 #include "Abstract.hpp"
 
@@ -132,6 +138,18 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 			}
 
 		private:
+
+#if IS_WINDOWS
+			/**
+			 * @brief Windows COM implementation of the dialog (IFileOpenDialog), shown with the
+			 * given parent window. Invoked by execute() on the dedicated STA thread set up by
+			 * runFileDialogOnDedicatedThread(). Windows-only.
+			 * @param window A reference to the application window.
+			 * @param parentWindow The native parent (centering owner) window handle, may be null.
+			 * @return bool
+			 */
+			bool showDialog (Window & window, HWND parentWindow) noexcept;
+#endif
 
 			std::vector< std::pair< std::string, std::vector< std::string > > > m_extensionFilters;
 			std::vector< std::filesystem::path > m_filepaths;

--- a/src/PlatformSpecific/Desktop/Dialog/OpenFile.windows.cpp
+++ b/src/PlatformSpecific/Desktop/Dialog/OpenFile.windows.cpp
@@ -242,49 +242,19 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 	bool
 	OpenFile::execute (Window & window, bool parentToWindow) noexcept
 	{
-		/* The native file dialog runs on a DEDICATED STA thread whose message queue is empty.
-		 *
-		 * Rationale: shown from the engine's main thread, the dialog's modal message loop pumps
-		 * the main thread's heavy message traffic (rendering, input, CEF). The Windows shell
-		 * reacts by re-resolving the navigation pane on every burst — thousands of redundant
-		 * known-folder / cloud-sync-root (SyncRootManager) registry lookups — which delays the
-		 * dialog by 3-5 s on machines whose known folders are redirected to a cloud provider
-		 * (e.g. OneDrive, the Windows default). On a dedicated thread the queue stays quiet, the
-		 * pane is resolved once, and the dialog appears in ~140 ms.
-		 *
-		 * We re-enter execute() on the worker (the thread-local guard prevents recursion) with
-		 * parentToWindow=false: the calling thread blocks on join() (execute() is synchronous by
-		 * contract), so giving the modal dialog a cross-thread owner window would risk a
-		 * message-pump deadlock. Trade-off: the dialog is not owned by the main window — harmless
-		 * here since the app is already blocked while the dialog is up. */
-		{
-			static thread_local bool onDedicatedDialogThread = false;
+		/* All native file dialogs run on a dedicated STA thread, centered on the application
+		 * window via a worker-thread owner proxy (no cross-thread owner). See
+		 * PlatformSpecific/Helpers.hpp (runFileDialogOnDedicatedThread) for the full rationale
+		 * (perf + deadlock-free centering). showDialog() below is the IFileOpenDialog body; it
+		 * receives the resolved parent window handle. */
+		return runFileDialogOnDedicatedThread(window, parentToWindow, [this, &window] (HWND parentWindow) {
+			return this->showDialog(window, parentWindow);
+		});
+	}
 
-			if ( !onDedicatedDialogThread )
-			{
-				bool result = false;
-
-				std::thread worker{[this, &window, &result] () {
-					onDedicatedDialogThread = true;
-
-					const HRESULT comInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-
-					result = this->execute(window, false);
-
-					if ( SUCCEEDED(comInit) )
-					{
-						CoUninitialize();
-					}
-				}};
-
-				worker.join();
-
-				return result;
-			}
-		}
-
-		HWND parentWindow = parentToWindow ? window.getWin32Window() : nullptr;
-
+	bool
+	OpenFile::showDialog (Window & window, HWND parentWindow) noexcept
+	{
 		/* NOTE: Branch to the Win32 legacy path when the compatibility setting is enabled.
 		 * Useful on Windows 11 when the modern COM dialog misbehaves with accessibility tools. */
 		if ( window.primaryServices().settings().getOrSetDefault< bool >(CompatibilityWindowsUseLegacyFileDialogsKey, DefaultCompatibilityWindowsUseLegacyFileDialogs) )

--- a/src/PlatformSpecific/Desktop/Dialog/SaveFile.hpp
+++ b/src/PlatformSpecific/Desktop/Dialog/SaveFile.hpp
@@ -31,6 +31,12 @@
 #include <utility>
 #include <vector>
 
+/* Local inclusions. */
+#include "emeraude_platform.hpp"
+#if IS_WINDOWS
+	#include "PlatformSpecific/Helpers.hpp" /* Provides the Win32 HWND type for the Windows-only showDialog(). */
+#endif
+
 /* Local inclusions for inheritances. */
 #include "Abstract.hpp"
 
@@ -139,6 +145,18 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 			}
 
 		private:
+
+#if IS_WINDOWS
+			/**
+			 * @brief Windows COM implementation of the dialog (IFileSaveDialog), shown with the
+			 * given parent window. Invoked by execute() on the dedicated STA thread set up by
+			 * runFileDialogOnDedicatedThread(). Windows-only.
+			 * @param window A reference to the application window.
+			 * @param parentWindow The native parent (centering owner) window handle, may be null.
+			 * @return bool
+			 */
+			bool showDialog (Window & window, HWND parentWindow) noexcept;
+#endif
 
 			std::vector< std::pair< std::string, std::vector< std::string > > > m_extensionFilters;
 			std::filesystem::path m_filepath;

--- a/src/PlatformSpecific/Desktop/Dialog/SaveFile.windows.cpp
+++ b/src/PlatformSpecific/Desktop/Dialog/SaveFile.windows.cpp
@@ -197,41 +197,19 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 	bool
 	SaveFile::execute (Window & window, bool parentToWindow) noexcept
 	{
-		/* The native file dialog runs on a DEDICATED STA thread whose message queue is empty.
-		 * See OpenFile::execute() for the full rationale: on the engine main thread the modal
-		 * message pump lets the Windows shell re-resolve its navigation pane thousands of times
-		 * (empty SyncRootManager / known-folder lookups), delaying the dialog by 3-5 s on
-		 * cloud-redirected-known-folder machines; a quiet thread resolves the pane once (~140 ms).
-		 * We re-enter execute() on the worker (thread-local guard prevents recursion) with
-		 * parentToWindow=false to avoid a cross-thread modal owner (the caller blocks on join()). */
-		{
-			static thread_local bool onDedicatedDialogThread = false;
+		/* All native file dialogs run on a dedicated STA thread, centered on the application
+		 * window via a worker-thread owner proxy (no cross-thread owner). See
+		 * PlatformSpecific/Helpers.hpp (runFileDialogOnDedicatedThread) for the full rationale
+		 * (perf + deadlock-free centering). showDialog() below is the IFileSaveDialog body; it
+		 * receives the resolved parent window handle. */
+		return runFileDialogOnDedicatedThread(window, parentToWindow, [this, &window] (HWND parentWindow) {
+			return this->showDialog(window, parentWindow);
+		});
+	}
 
-			if ( !onDedicatedDialogThread )
-			{
-				bool result = false;
-
-				std::thread worker{[this, &window, &result] () {
-					onDedicatedDialogThread = true;
-
-					const HRESULT comInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-
-					result = this->execute(window, false);
-
-					if ( SUCCEEDED(comInit) )
-					{
-						CoUninitialize();
-					}
-				}};
-
-				worker.join();
-
-				return result;
-			}
-		}
-
-		HWND parentWindow = parentToWindow ? window.getWin32Window() : nullptr;
-
+	bool
+	SaveFile::showDialog (Window & window, HWND parentWindow) noexcept
+	{
 		/* NOTE: Branch to the Win32 legacy path when the compatibility setting is enabled.
 		 * Useful on Windows 11 when the modern COM dialog misbehaves with accessibility tools. */
 		if ( window.primaryServices().settings().getOrSetDefault< bool >(CompatibilityWindowsUseLegacyFileDialogsKey, DefaultCompatibilityWindowsUseLegacyFileDialogs) )

--- a/src/PlatformSpecific/Helpers.hpp
+++ b/src/PlatformSpecific/Helpers.hpp
@@ -31,6 +31,7 @@
 
 /* STL inclusions. */
 #if IS_WINDOWS
+	#include <functional>
 	#include <map>
 #endif
 #include <string>
@@ -48,6 +49,14 @@
 
 	#include <Windows.h>
 	#include <shtypes.h>
+#endif
+
+#if IS_WINDOWS
+/* Forward declarations. */
+namespace EmEn
+{
+	class Window;
+}
 #endif
 
 namespace EmEn::PlatformSpecific
@@ -138,6 +147,40 @@ namespace EmEn::PlatformSpecific
 	 */
 	[[nodiscard]]
 	std::vector< COMDLG_FILTERSPEC > createExtensionFilter (const std::vector< std::pair< std::string, std::vector< std::string > > > & filters, std::map< std::wstring, std::wstring > & dataHolder);
+
+	/**
+	 * @brief Runs a native Windows file-dialog body on a DEDICATED STA thread, with the dialog
+	 * centered on the application window — without a cross-thread owner.
+	 *
+	 * Shared machinery for OpenFile/SaveFile (the dialog-specific COM code is the @a dialogBody).
+	 * It encapsulates three concerns that are identical for every native file dialog:
+	 *
+	 * 1. **Perf:** the dialog runs on a fresh STA thread whose message queue is empty, instead of
+	 *    the engine's main thread. On the main thread the modal message loop pumps the heavy main
+	 *    traffic (rendering, input, CEF), making the Windows shell re-resolve its navigation pane
+	 *    thousands of times (empty SyncRootManager / known-folder lookups) — a 3-5 s delay on
+	 *    cloud-redirected-known-folder machines. A quiet thread resolves the pane once (~140 ms).
+	 *
+	 * 2. **Centering:** a hidden owner window is created ON THE WORKER THREAD, over the
+	 *    main window's screen rectangle (read on the caller thread, passed by value, with the main
+	 *    window's DPI awareness context replicated). The shell centers the dialog on it natively —
+	 *    no post-show jump, correct monitor. A cross-thread owner is impossible here: the caller
+	 *    blocks on join() while the dialog is up, so a modal dialog owned by a window on that
+	 *    blocked thread would deadlock on the implicit cross-thread WM_ENABLE / activation sends.
+	 *    The proxy lives on the worker thread → those sends stay same-thread.
+	 *
+	 * 3. **COM:** CoInitializeEx(STA) / CoUninitialize around the body.
+	 *
+	 * @param window A reference to the application window (read on the caller thread only).
+	 * @param parentToWindow Whether to center on @a window. When false, the body receives a null
+	 * parent (no centering) — matches the previous behavior for ownerless dialogs.
+	 * @param dialogBody The dialog-specific work. Receives the parent window handle to pass to
+	 * IFileDialog::Show() (and the legacy hwndOwner). Runs on the dedicated STA thread. Returns
+	 * its own success flag, which becomes this function's return value.
+	 * @return bool
+	 */
+	[[nodiscard]]
+	bool runFileDialogOnDedicatedThread (Window & window, bool parentToWindow, const std::function< bool (HWND parentWindow) > & dialogBody) noexcept;
 #endif
 
 #if IS_LINUX

--- a/src/PlatformSpecific/Helpers.windows.cpp
+++ b/src/PlatformSpecific/Helpers.windows.cpp
@@ -27,8 +27,12 @@
 #include "Helpers.hpp"
 
 /* STL inclusions. */
+#include <exception>
+#include <functional>
 #include <iostream>
+#include <optional>
 #include <stdexcept>
+#include <thread>
 
 /* Third-party inclusions. */
 #ifndef NOMINMAX
@@ -38,11 +42,13 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <Windows.h>
+#include <objbase.h>
 #include <psapi.h>
 #include <tlhelp32.h>
 
 /* Local inclusions. */
 #include "Tracer.hpp"
+#include "Window.hpp"
 
 namespace EmEn::PlatformSpecific
 {
@@ -364,5 +370,145 @@ namespace EmEn::PlatformSpecific
 		}
 
 		return filterPointers;
+	}
+
+	namespace
+	{
+		constexpr auto FileDialogClassId{"FileDialog"};
+
+		/**
+		 * @brief Hidden top-level owner window positioned over a target screen rectangle, created
+		 * on the calling (STA worker) thread so the shell centers the modal dialog on it WITHOUT a
+		 * cross-thread owner.
+		 *
+		 * Uses the built-in "STATIC" class (no RegisterClass, no class-atom lifetime concern) and
+		 * is never shown (no WS_VISIBLE) — the shell only needs its geometry. Created and destroyed
+		 * (RAII) on the same thread as the dialog's modal loop, so the implicit owner enable/disable
+		 * sends stay same-thread and cannot deadlock against the blocked caller thread.
+		 */
+		class CenteringOwner final
+		{
+			public:
+
+				explicit
+				CenteringOwner (const RECT * targetRect) noexcept
+				{
+					if ( targetRect == nullptr )
+					{
+						return;
+					}
+
+					const LONG rawWidth = targetRect->right - targetRect->left;
+					const LONG rawHeight = targetRect->bottom - targetRect->top;
+					const int width = rawWidth > 1 ? static_cast< int >(rawWidth) : 1;
+					const int height = rawHeight > 1 ? static_cast< int >(rawHeight) : 1;
+
+					m_handle = CreateWindowExW(
+						WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
+						L"STATIC", L"",
+						WS_POPUP,
+						static_cast< int >(targetRect->left), static_cast< int >(targetRect->top),
+						width, height,
+						nullptr, nullptr, GetModuleHandleW(nullptr), nullptr);
+				}
+
+				CenteringOwner (const CenteringOwner &) = delete;
+
+				CenteringOwner (CenteringOwner &&) = delete;
+
+				CenteringOwner & operator= (const CenteringOwner &) = delete;
+
+				CenteringOwner & operator= (CenteringOwner &&) = delete;
+
+				~CenteringOwner ()
+				{
+					if ( m_handle != nullptr )
+					{
+						DestroyWindow(m_handle);
+					}
+				}
+
+				[[nodiscard]]
+				HWND
+				handle () const noexcept
+				{
+					return m_handle;
+				}
+
+			private:
+
+				HWND m_handle{nullptr};
+		};
+	}
+
+	bool
+	runFileDialogOnDedicatedThread (Window & window, bool parentToWindow, const std::function< bool (HWND) > & dialogBody) noexcept
+	{
+		/* Read the main window geometry + DPI context on the CALLER thread; never deref the main
+		 * window HWND from the worker.
+		 *
+		 * Skip the centering owner when the window is minimized: GetWindowRect then returns the
+		 * iconic ghost coordinates (~{-32000, -32000}), which would center the dialog off-screen.
+		 * With no owner rect we fall back to the shell's default (visible) placement. We test
+		 * IsIconic rather than the coordinate sign — a window on a left secondary monitor has a
+		 * legitimately negative X. */
+		const HWND mainWindow = window.getWin32Window();
+		RECT ownerRect{};
+		const bool haveOwnerRect = parentToWindow && mainWindow != nullptr && IsIconic(mainWindow) == 0 && GetWindowRect(mainWindow, &ownerRect) != 0;
+		const DPI_AWARENESS_CONTEXT dpiContext = mainWindow != nullptr ? GetWindowDpiAwarenessContext(mainWindow) : nullptr;
+
+		/* The actual dialog run: STA COM init + hidden centering owner + body, on whichever thread
+		 * invokes it (the dedicated worker normally, the caller thread on the fallback path). */
+		const auto runDialog = [&dialogBody, haveOwnerRect, &ownerRect] () -> bool {
+			const HRESULT comInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+
+			/* RAII hidden owner, created and destroyed on the running thread. */
+			const CenteringOwner owner{haveOwnerRect ? &ownerRect : nullptr};
+
+			const bool dialogResult = dialogBody(owner.handle());
+
+			if ( SUCCEEDED(comInit) )
+			{
+				CoUninitialize();
+			}
+
+			return dialogResult;
+		};
+
+		bool result = false;
+
+		/* The dialog runs on a DEDICATED STA thread (empty message queue) — see the header for the
+		 * full perf rationale. The DPI awareness is replicated on the worker ONLY; setting it on the
+		 * caller thread would permanently mutate the main thread's context.
+		 *
+		 * Only the thread CONSTRUCTION is guarded: it is the sole realistic failure (std::thread
+		 * throws std::system_error on OS resource exhaustion). join() on a freshly joinable thread
+		 * does not throw, so it stays outside the try. */
+		std::optional< std::thread > worker;
+
+		try
+		{
+			worker.emplace([&runDialog, &result, dpiContext] () {
+				if ( dpiContext != nullptr )
+				{
+					SetThreadDpiAwarenessContext(dpiContext);
+				}
+
+				result = runDialog();
+			});
+		}
+		catch ( const std::exception & error )
+		{
+			/* Spawning the dedicated thread failed. Fall back to running the dialog on the caller
+			 * thread: slower on cloud-redirected-known-folder machines (the original symptom), but
+			 * functional. No DPI mutation here — the caller thread already owns the window. */
+			TraceWarning{FileDialogClassId} << "Unable to spawn the dedicated dialog thread (" << error.what() << "); running the dialog inline.";
+
+			return runDialog();
+		}
+
+		worker->join();
+
+		return result;
 	}
 }


### PR DESCRIPTION
https://mango3d.atlassian.net/browse/TECH-1838

**Problème**

Le correctif perf précédent (dialogues fichier Windows déplacés sur un thread STA dédié pour éliminer un gel de 3–5 s) avait introduit une régression de placement : en passant Show(nullptr), le dialogue n'était plus centré sur la fenêtre LycheeSlicer (position shell par défaut, mauvais écran en multi-moniteurs). On ne pouvait pas simplement remettre la fenêtre principale comme owner : elle vit sur le thread principal bloqué sur join(), et un owner modal cross-thread risque un deadlock de pompe de messages.

**Solution**

Piste « proxy-owner » : créer une fenêtre owner cachée sur le thread STA dédié lui-même (même thread que la boucle modale → pas de cross-thread → pas de deadlock), positionnée sur le rectangle écran de la fenêtre principale. Le shell centre alors le dialogue nativement, sans saut ni flash, et sans réintroduire la lenteur (le lag dépend du thread qui pompe, pas de l'owner).

**Implémentation**

- Win32DialogThread.hpp / .windows.cpp (nouveaux) — helper partagé runFileDialogOnDedicatedThread(...) factorisant toute la mécanique (thread STA + COM + proxy de centrage), auparavant dupliquée. Contient CenteringOwner (RAII, classe STATIC/WS_POPUP invisible).
- OpenFile/SaveFile.windows.cpp — execute() réduit à un wrapper appelant le helper ; le code COM déplacé tel quel dans une méthode privée showDialog(Window&, HWND).
- OpenFile/SaveFile.hpp — showDialog privée sous #if IS_WINDOWS, forward-decl HWND__ (pas de <windows.h> en en-tête).
- CMake + doc (AGENTS.md, TECH-1838.md) mis à jour.

Détails de robustesse retenus en revue : RECT/DPI lus sur le thread appelant et passés par valeur ; SetThreadDpiAwarenessContext sur le worker uniquement (multi-écrans) ; try/catch (Option A) sur la seule création du thread avec repli inline ; guard IsIconic pour éviter un dialogue hors écran quand la fenêtre est minimisée.
