### PR TITLE
TECH-1927 redefine ownership for the file dialog box (windows)

### DIFF
--- a/src/PlatformSpecific/AGENTS.md
+++ b/src/PlatformSpecific/AGENTS.md
@@ -66,7 +66,7 @@ PlatformSpecific/
 ├── Helpers.linux.cpp            # Linux helper implementations
 ├── Helpers.mac.cpp              # macOS helper implementations
 ├── Helpers.windows.cpp          # Windows helper implementations (incl. runFileDialogOnDedicatedThread()
-│                                #   + file-local CenteringOwner — dedicated STA thread + centering proxy)
+│                                #   — dedicated STA thread, dialog owned by the real main window)
 ├── SystemInfo.hpp/.cpp          # System information (+ hybrid CPU detection via hwloc)
 ├── UserInfo.hpp/.cpp            # User information (+ platform files)
 ├── Types.hpp                    # Common type definitions (CPU struct with E/P-core counts)
@@ -92,10 +92,9 @@ PlatformSpecific/
 ```
 
 > [!NOTE]
-> The Windows dedicated-STA-thread file-dialog helper (`runFileDialogOnDedicatedThread()`
-> + the file-local `CenteringOwner`) lives in `PlatformSpecific/Helpers.{hpp,windows.cpp}`,
-> **not** under `Desktop/Dialog/` — it is OS-machinery shared by `OpenFile`/`SaveFile`, so it
-> sits with the other Windows helpers.
+> The Windows dedicated-STA-thread file-dialog helper (`runFileDialogOnDedicatedThread()`) lives in
+> `PlatformSpecific/Helpers.{hpp,windows.cpp}`, **not** under `Desktop/Dialog/` — it is OS-machinery
+> shared by `OpenFile`/`SaveFile`, so it sits with the other Windows helpers.
 
 ### File Naming Convention
 
@@ -117,50 +116,114 @@ CMake selects the appropriate file based on target platform.
 wrapper that delegates to the shared helper `runFileDialogOnDedicatedThread()`
 (`Helpers.hpp` / `Helpers.windows.cpp`): it spawns a **dedicated STA thread** with an empty
 message queue, runs the dialog body (`OpenFile::showDialog` / `SaveFile::showDialog`) there, and
-`join()`s it. The helper owns the thread, COM init, and the centering proxy; the per-dialog
-`showDialog()` only does the COM dialog work and receives the resolved parent `HWND`. On failure
-to spawn the worker (OS resource exhaustion), it falls back to running the dialog inline on the
-caller thread.
+waits for it. The helper owns the thread, COM init, the cross-thread owner handshake
+(`AttachThreadInput`) and the message-pumping wait; the per-dialog `showDialog()` only does the COM
+dialog work and receives the owner `HWND`. On failure to spawn the worker (OS resource exhaustion),
+it falls back to running the dialog inline on the caller thread.
 
-**Why (perf):** on the main thread the dialog's modal message loop pumps the heavy main-thread
-traffic (rendering, input, CEF). The Windows shell reacts by re-resolving its navigation pane on
-every burst — thousands of redundant known-folder / cloud-sync-root (`SyncRootManager`) registry
-lookups — delaying the dialog **3–5 s** on machines whose known folders are redirected to a cloud
-provider (OneDrive, the Windows default). On a quiet dedicated thread the pane resolves once and
-the dialog appears in **~140 ms**.
+**Why (perf):** the dialog's modal message loop pumps **every** message of the thread it runs on.
+On the engine main thread that means the heavy main-thread traffic (rendering, input, and — under
+app_system — CEF), and the Windows shell reacts by re-resolving its navigation pane on every burst:
+thousands of redundant known-folder / cloud-sync-root (`SyncRootManager`) registry lookups. On a
+machine whose known folders are redirected to a cloud provider (OneDrive, the Windows default), this
+delays the dialog **3–5 s**. A dedicated thread has an empty message queue, so the pane resolves once
+and the dialog appears in **~140 ms** (measured ≈×25 speed-up). Apps with an idle UI thread (e.g.
+Notepad++) never hit this — which is why the same dialog is instant elsewhere on the same machine.
 
 > [!WARNING]
 > Do **not** "simplify" by calling `Show()` directly on the calling thread — it silently
 > reintroduces the 3–5 s freeze on any machine with cloud-redirected known folders (invisible on
 > a plain dev box, hence hard to diagnose).
 
-### Dialog centering — `CenteringOwner` (TECH-1838)
+### Owner-based modality, centering & Z-order
 
-Passing the main window as the modal dialog's owner is **not** possible here: the main window
-lives on the main thread, which is blocked on `join()` while the dialog is up, so a cross-thread
-owner risks a message-pump deadlock (the modal dialog's implicit `WM_ENABLE` / activation sends to
-the owner thread would never return). The first perf fix therefore used a **null owner** — which
-also dropped native placement (dialog no longer centered on the app window, wrong monitor in
-multi-screen). Note the lag and the owner are **independent**: the lag is purely a function of the
-thread on which `Show()` pumps messages, not of the owner — so the centering fix below does not
-reintroduce it.
+The dialog is shown **owned by the real main window** (its `HWND` is passed to the dialog body and
+fed to `IFileDialog::Show(owner)` and the legacy `OPENFILENAMEW.hwndOwner` / `BROWSEINFOW.hwndOwner`).
+Win32 owner relationships are the OS-native mechanism for all three behaviors the dialog needs, so
+the OS handles them for free:
 
-`runFileDialogOnDedicatedThread()` restores placement **without** a cross-thread owner:
+- **Modality** — the OS disables the owner while the dialog is up.
+- **Centering** — the shell positions the dialog on its owner, correct monitor, no post-show jump.
+- **Z-order** — an owned window is always above its owner and is **raised with it on activation**, so
+  the dialog resurfaces after an alt-tab / taskbar click instead of being buried behind the main
+  window.
 
-1. On the **caller thread**, before spawning the worker, it reads the main window's screen
-   rectangle (`GetWindowRect`) and DPI awareness context (`GetWindowDpiAwarenessContext`), passed
-   **by value** to the worker (no cross-thread HWND deref on the worker).
-2. On the **worker (STA) thread**, `SetThreadDpiAwarenessContext(...)` matches the main window,
-   then a `CenteringOwner` (file-local in `Helpers.windows.cpp`) is built — a hidden
-   top-level window (built-in `STATIC` class, `WS_POPUP` without `WS_VISIBLE`) positioned over that
-   rectangle. It is created **and destroyed on the worker thread** (RAII), so there is **no
-   cross-thread owner** and no deadlock risk — the owner enable/disable sends stay same-thread.
-3. The proxy `HWND` is passed to the dialog body, which feeds it to `Show(parentWindow)` and to the
-   legacy `OPENFILENAMEW.hwndOwner` / `BROWSEINFOW.hwndOwner` paths.
+The owner is **cross-thread**: the dialog runs on the worker (STA) thread, the owner lives on the
+main thread. A cross-thread owner deadlocks if the owner thread stops pumping messages (e.g. a bare
+`join()`), so it is made safe here by two things the helper does:
 
-The shell centers the dialog on the proxy natively, at creation time — **no post-show jump, no
-flash**, correct monitor in multi-screen. The proxy is never shown; the shell only needs its
-geometry.
+1. **The caller pumps messages while it waits** (see § Responsiveness) — so the owner's implicit
+   `WM_ENABLE` / activation sends, dispatched from the worker, are serviced instead of deadlocking.
+2. **`AttachThreadInput(workerThreadId, ownerThreadId, TRUE)`** for the dialog's lifetime — merges the
+   two threads' input state so activation and **focus return on close** behave as if same-thread.
+   It is detached after the dialog returns. (Attaching a thread to itself fails harmlessly on the
+   inline-fallback path, where owner and dialog are already on the same thread.)
+
+The worker still replicates the owner's DPI awareness context (`SetThreadDpiAwarenessContext`) so the
+dialog renders at the right scale. Everything is **gated on `parentToWindow`**: when it is `false`
+the dialog is shown with a null owner — no modality, no centering — for callers that deliberately
+want an ownerless dialog.
+
+### Responsiveness — message-pumping wait
+
+`execute()` is synchronous by contract (the app_system IPC handler needs the result to send its
+ZeroMQ reply), so the caller must wait for the worker — but a bare `join()` **hard-blocks** the main
+thread, which breaks two things:
+
+1. The dialog **owns the main window cross-thread**, so the OS dispatches `WM_ENABLE` / activation
+   sends to the main thread from the worker; a non-pumping thread never services them, deadlocking
+   the native modal handshake.
+2. After ~5 s a non-pumping thread is marked **"Not Responding"** (DWM ghost: greyed snapshot,
+   spinning cursor), even though the dialog is alive on the worker.
+
+`runFileDialogOnDedicatedThread()` therefore replaces the bare `join()` with a **drain-then-wait**
+loop on the worker's thread handle: each iteration first drains the caller thread's own queue
+(`PeekMessage` / `Translate` / `Dispatch`), then blocks in `MsgWaitForMultipleObjectsEx` until the
+worker terminates or new serviceable work arrives, then `join()`s (which returns immediately).
+`WM_QUIT` is handled specially — it is re-posted (`PostQuitMessage`) and the dialog is waited out, so
+the engine's main loop sees the quit only after the dialog closes.
+
+> [!WARNING]
+> The wake mask **excludes `QS_INPUT`** (it is `QS_PAINT | QS_TIMER | QS_POSTMESSAGE |
+> QS_SENDMESSAGE`), and `MWMO_INPUTAVAILABLE` is **not** used (hence drain-*first*). This is not
+> cosmetic: `AttachThreadInput` shares the worker's input queue with the main thread, so mouse-moves
+> / keystrokes aimed at the **dialog** flag input as "available" on the main thread. With `QS_INPUT`
+> in the mask (or with `MWMO_INPUTAVAILABLE`), the wait would return immediately and repeatedly while
+> `PeekMessage` — which only retrieves messages for the main thread's *own* windows — removes nothing:
+> a **100 % CPU busy-spin whenever the user moves the mouse over the dialog**. The main window is
+> disabled by the modal and has no input to process anyway; it only needs paint / posted (CEF) / timer
+> messages. Sent messages (the owner's `WM_ENABLE` / activation handshake) are serviced by the wait
+> regardless of the mask.
+
+This does **not** reintroduce the 3–5 s perf storm: that was the *dialog's* modal loop pumping heavy
+traffic, and the dialog's loop runs on the worker. This pump only services the main thread's own
+messages (paint, CEF, DWM responsiveness pings). The main window is disabled by the native modal (it
+is the owner), so the pumped input is ignored — **responsive but non-interactive**, the correct
+modal behavior.
+
+### Reentrancy — a reentrant open is refused, not nested
+
+The pump above dispatches messages, which re-enters the main window's `WndProc`. A dispatched
+message can call back into `runFileDialogOnDedicatedThread()` to open a **second** native file dialog
+on the same thread. This is **refused at the top of the function** (a `thread_local` "active" flag,
+RAII-scoped over the whole operation): a reentrant call logs a warning and returns `false`, which the
+caller treats as a cancellation.
+
+Refusing — rather than nesting — is the only robust fix, because the damage is done by the nested
+dialog *opening*, not by any nested pumping:
+
+- A nested dialog owned by the same main window calls `EnableWindow(owner, FALSE)` on `Show()` and
+  `EnableWindow(owner, TRUE)` on close. Win32 owner enable/disable is **not ref-counted**, so the
+  inner dialog's close would **re-enable the main window while the outer dialog is still modal** —
+  the app becomes interactive under an open modal. Preventing the nested `Show()` is what closes this
+  hole; merely avoiding a nested pump would not.
+- Two stacked native file choosers are not a meaningful UX anyway.
+
+> [!WARNING]
+> Do **not** "fix" a reentrant dialog request by opening it on another worker/owner or by pumping
+> differently — a second dialog owned by the same window reopens the non-ref-counted owner-enable
+> hole above. The reentrant request must be refused (or deferred by the caller until the first
+> dialog closes).
 
 ---
 
@@ -283,37 +346,14 @@ See: `Dialog/SaveFile.hpp:setDefaultFilename()`, `Dialog/SaveFile.hpp:setDefault
 | Linux | kdialog positional arg / zenity `--filename=` | Same | Appended to path arg | Handled by desktop tool |
 | macOS | `NSOpenPanel setDirectoryURL:` | `NSSavePanel setDirectoryURL:` | `setNameFieldStringValue:` | Handled by `allowedContentTypes` |
 
-### Windows: native file dialogs run on a dedicated STA thread (critical)
+### Windows dialog mechanism (dedicated STA thread, main-window owner)
 
-On Windows, `OpenFile::execute()` and `SaveFile::execute()` show the modern
-`IFileOpenDialog` / `IFileSaveDialog` on a **dedicated STA thread**, not on the calling
-thread. This is mandatory for performance — not stylistic.
-
-**Why:** the dialog's modal message loop pumps **every** message of the thread it runs on.
-Shown from a busy thread (the engine main loop pumping rendering, input, and — under
-app_system — CEF), the Windows shell re-resolves its navigation pane on every message
-burst: thousands of redundant known-folder / cloud-sync-root (`SyncRootManager`) registry
-lookups. On a machine whose known folders are redirected to a cloud provider (OneDrive —
-the Windows default), this delays the dialog by **3–5 s**. A dedicated thread has an empty
-message queue, so the pane is resolved once and the dialog appears in ~140 ms (measured
-×25 speed-up). Apps with an idle UI thread (e.g. Notepad++) never hit this — which is why
-the same dialog is instant elsewhere on the same machine.
-
-**Implementation:** `execute()` delegates to `runFileDialogOnDedicatedThread()`
-(`Helpers.{hpp,windows.cpp}`), passing its COM dialog body (`showDialog()`) as a callback. The
-helper spawns a `std::thread` that `CoInitializeEx(STA)`s, builds the hidden `CenteringOwner`
-(see § Dialog centering above), runs the body, then `join()`s — the caller blocks on `join()`
-because `execute()` is synchronous by contract. The centering owner is created **on the worker
-thread** (never a cross-thread owner), which is what makes native centering possible without a
-modal-pump deadlock. If the worker thread cannot be spawned, the helper runs the dialog inline on
-the caller thread (slower on cloud-redirected machines, but functional). See the comment block in
-`Dialog/OpenFile.windows.cpp` and `Helpers.windows.cpp`.
-
-> [!WARNING]
-> Do **not** "simplify" this back to a direct `Show()` on the calling thread — it silently
-> reintroduces the 3–5 s freeze on any machine with cloud-redirected known folders (i.e.
-> most Windows installs with OneDrive). The cost is invisible on a developer machine
-> without OneDrive folder redirection.
+On Windows, `OpenFile::execute()` / `SaveFile::execute()` delegate to
+`runFileDialogOnDedicatedThread()`, which shows the modern `IFileOpenDialog` / `IFileSaveDialog` on a
+**dedicated STA thread owned by the main window**. The complete rationale and mechanism — perf
+(why a dedicated thread), owner-based modality / centering / Z-order, and the message-pumping wait —
+are documented once in the top-level section **§ Windows: native file dialogs run on a dedicated STA
+thread** (above). It is not repeated here to avoid drift.
 
 ### Linux Dialog Implementation (zenity/kdialog)
 

--- a/src/PlatformSpecific/Desktop/Dialog/OpenFile.windows.cpp
+++ b/src/PlatformSpecific/Desktop/Dialog/OpenFile.windows.cpp
@@ -36,7 +36,6 @@
 /* STL inclusions. */
 #include <filesystem>
 #include <map>
-#include <thread>
 #include <vector>
 
 /* Third-party inclusions. */
@@ -242,11 +241,11 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 	bool
 	OpenFile::execute (Window & window, bool parentToWindow) noexcept
 	{
-		/* All native file dialogs run on a dedicated STA thread, centered on the application
-		 * window via a worker-thread owner proxy (no cross-thread owner). See
+		/* All native file dialogs run on a dedicated STA thread, owned by the real main window (a
+		 * cross-thread owner, made safe by the message-pumping wait + AttachThreadInput). See
 		 * PlatformSpecific/Helpers.hpp (runFileDialogOnDedicatedThread) for the full rationale
-		 * (perf + deadlock-free centering). showDialog() below is the IFileOpenDialog body; it
-		 * receives the resolved parent window handle. */
+		 * (perf + owner-based modality/centering/Z-order + reentrancy-safe wait). showDialog() below
+		 * is the IFileOpenDialog body; it receives the owner window handle. */
 		return runFileDialogOnDedicatedThread(window, parentToWindow, [this, &window] (HWND parentWindow) {
 			return this->showDialog(window, parentWindow);
 		});

--- a/src/PlatformSpecific/Desktop/Dialog/SaveFile.windows.cpp
+++ b/src/PlatformSpecific/Desktop/Dialog/SaveFile.windows.cpp
@@ -37,7 +37,6 @@
 #include <algorithm>
 #include <filesystem>
 #include <map>
-#include <thread>
 #include <vector>
 
 /* Third-party inclusions. */
@@ -197,11 +196,11 @@ namespace EmEn::PlatformSpecific::Desktop::Dialog
 	bool
 	SaveFile::execute (Window & window, bool parentToWindow) noexcept
 	{
-		/* All native file dialogs run on a dedicated STA thread, centered on the application
-		 * window via a worker-thread owner proxy (no cross-thread owner). See
+		/* All native file dialogs run on a dedicated STA thread, owned by the real main window (a
+		 * cross-thread owner, made safe by the message-pumping wait + AttachThreadInput). See
 		 * PlatformSpecific/Helpers.hpp (runFileDialogOnDedicatedThread) for the full rationale
-		 * (perf + deadlock-free centering). showDialog() below is the IFileSaveDialog body; it
-		 * receives the resolved parent window handle. */
+		 * (perf + owner-based modality/centering/Z-order + reentrancy-safe wait). showDialog() below
+		 * is the IFileSaveDialog body; it receives the owner window handle. */
 		return runFileDialogOnDedicatedThread(window, parentToWindow, [this, &window] (HWND parentWindow) {
 			return this->showDialog(window, parentWindow);
 		});

--- a/src/PlatformSpecific/Helpers.hpp
+++ b/src/PlatformSpecific/Helpers.hpp
@@ -149,11 +149,11 @@ namespace EmEn::PlatformSpecific
 	std::vector< COMDLG_FILTERSPEC > createExtensionFilter (const std::vector< std::pair< std::string, std::vector< std::string > > > & filters, std::map< std::wstring, std::wstring > & dataHolder);
 
 	/**
-	 * @brief Runs a native Windows file-dialog body on a DEDICATED STA thread, with the dialog
-	 * centered on the application window — without a cross-thread owner.
+	 * @brief Runs a native Windows file-dialog body on a DEDICATED STA thread, owned by the real
+	 * application window so the OS provides native modality, centering and Z-order.
 	 *
 	 * Shared machinery for OpenFile/SaveFile (the dialog-specific COM code is the @a dialogBody).
-	 * It encapsulates three concerns that are identical for every native file dialog:
+	 * It reconciles two otherwise-conflicting needs:
 	 *
 	 * 1. **Perf:** the dialog runs on a fresh STA thread whose message queue is empty, instead of
 	 *    the engine's main thread. On the main thread the modal message loop pumps the heavy main
@@ -161,26 +161,29 @@ namespace EmEn::PlatformSpecific
 	 *    thousands of times (empty SyncRootManager / known-folder lookups) — a 3-5 s delay on
 	 *    cloud-redirected-known-folder machines. A quiet thread resolves the pane once (~140 ms).
 	 *
-	 * 2. **Centering:** a hidden owner window is created ON THE WORKER THREAD, over the
-	 *    main window's screen rectangle (read on the caller thread, passed by value, with the main
-	 *    window's DPI awareness context replicated). The shell centers the dialog on it natively —
-	 *    no post-show jump, correct monitor. A cross-thread owner is impossible here: the caller
-	 *    blocks on join() while the dialog is up, so a modal dialog owned by a window on that
-	 *    blocked thread would deadlock on the implicit cross-thread WM_ENABLE / activation sends.
-	 *    The proxy lives on the worker thread → those sends stay same-thread.
+	 * 2. **Native owner behavior:** the dialog is shown OWNED BY the real main window (passed to
+	 *    @a dialogBody as the parent HWND). The OS then disables the owner (modality), centers the
+	 *    dialog on it (placement), and keeps it above the owner in Z-order — so it resurfaces with
+	 *    the main window after an alt-tab / taskbar click, instead of being buried. The owner is
+	 *    cross-thread (dialog on the worker, owner on the main thread); this is made safe by (a) the
+	 *    caller PUMPING messages while it waits — see the implementation — so the owner's
+	 *    enable/disable/activation sends complete instead of deadlocking, and (b) AttachThreadInput
+	 *    merging the two threads' input state for the dialog's lifetime so activation / focus return
+	 *    behave as if same-thread. The worker also replicates the owner's DPI awareness context.
 	 *
-	 * 3. **COM:** CoInitializeEx(STA) / CoUninitialize around the body.
+	 * COM (CoInitializeEx STA / CoUninitialize) wraps the body. If the worker thread cannot be
+	 * spawned, the body runs inline on the caller thread (slower, but functional).
 	 *
 	 * @param window A reference to the application window (read on the caller thread only).
-	 * @param parentToWindow Whether to center on @a window. When false, the body receives a null
-	 * parent (no centering) — matches the previous behavior for ownerless dialogs.
-	 * @param dialogBody The dialog-specific work. Receives the parent window handle to pass to
+	 * @param parentToWindow Whether to own/center on @a window. When false, the body receives a null
+	 * owner: the dialog is shown ownerless — no modality, no centering.
+	 * @param dialogBody The dialog-specific work. Receives the owner window handle to pass to
 	 * IFileDialog::Show() (and the legacy hwndOwner). Runs on the dedicated STA thread. Returns
 	 * its own success flag, which becomes this function's return value.
 	 * @return bool
 	 */
 	[[nodiscard]]
-	bool runFileDialogOnDedicatedThread (Window & window, bool parentToWindow, const std::function< bool (HWND parentWindow) > & dialogBody) noexcept;
+	bool runFileDialogOnDedicatedThread (Window & window, bool parentToWindow, const std::function< bool (HWND ownerWindow) > & dialogBody) noexcept;
 #endif
 
 #if IS_LINUX

--- a/src/PlatformSpecific/Helpers.windows.cpp
+++ b/src/PlatformSpecific/Helpers.windows.cpp
@@ -375,97 +375,70 @@ namespace EmEn::PlatformSpecific
 	namespace
 	{
 		constexpr auto FileDialogClassId{"FileDialog"};
-
-		/**
-		 * @brief Hidden top-level owner window positioned over a target screen rectangle, created
-		 * on the calling (STA worker) thread so the shell centers the modal dialog on it WITHOUT a
-		 * cross-thread owner.
-		 *
-		 * Uses the built-in "STATIC" class (no RegisterClass, no class-atom lifetime concern) and
-		 * is never shown (no WS_VISIBLE) — the shell only needs its geometry. Created and destroyed
-		 * (RAII) on the same thread as the dialog's modal loop, so the implicit owner enable/disable
-		 * sends stay same-thread and cannot deadlock against the blocked caller thread.
-		 */
-		class CenteringOwner final
-		{
-			public:
-
-				explicit
-				CenteringOwner (const RECT * targetRect) noexcept
-				{
-					if ( targetRect == nullptr )
-					{
-						return;
-					}
-
-					const LONG rawWidth = targetRect->right - targetRect->left;
-					const LONG rawHeight = targetRect->bottom - targetRect->top;
-					const int width = rawWidth > 1 ? static_cast< int >(rawWidth) : 1;
-					const int height = rawHeight > 1 ? static_cast< int >(rawHeight) : 1;
-
-					m_handle = CreateWindowExW(
-						WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
-						L"STATIC", L"",
-						WS_POPUP,
-						static_cast< int >(targetRect->left), static_cast< int >(targetRect->top),
-						width, height,
-						nullptr, nullptr, GetModuleHandleW(nullptr), nullptr);
-				}
-
-				CenteringOwner (const CenteringOwner &) = delete;
-
-				CenteringOwner (CenteringOwner &&) = delete;
-
-				CenteringOwner & operator= (const CenteringOwner &) = delete;
-
-				CenteringOwner & operator= (CenteringOwner &&) = delete;
-
-				~CenteringOwner ()
-				{
-					if ( m_handle != nullptr )
-					{
-						DestroyWindow(m_handle);
-					}
-				}
-
-				[[nodiscard]]
-				HWND
-				handle () const noexcept
-				{
-					return m_handle;
-				}
-
-			private:
-
-				HWND m_handle{nullptr};
-		};
 	}
 
 	bool
 	runFileDialogOnDedicatedThread (Window & window, bool parentToWindow, const std::function< bool (HWND) > & dialogBody) noexcept
 	{
-		/* Read the main window geometry + DPI context on the CALLER thread; never deref the main
-		 * window HWND from the worker.
-		 *
-		 * Skip the centering owner when the window is minimized: GetWindowRect then returns the
-		 * iconic ghost coordinates (~{-32000, -32000}), which would center the dialog off-screen.
-		 * With no owner rect we fall back to the shell's default (visible) placement. We test
-		 * IsIconic rather than the coordinate sign — a window on a left secondary monitor has a
-		 * legitimately negative X. */
+		/* Reentrancy guard. While the dialog is up, the caller pumps its message queue (below), which
+		 * re-enters the main window's WndProc; a dispatched message can call back into this function to
+		 * open a SECOND native file dialog on the same thread. That is refused outright: two stacked
+		 * native file choosers make no UX sense, and — more importantly — a nested dialog owned by the
+		 * same main window would EnableWindow(owner, TRUE) on close (Win32 owner enable/disable is NOT
+		 * ref-counted), re-enabling the main window while the outer dialog is still modal. Refusing at
+		 * the top prevents the nested Show() entirely, which is the only robust fix. A refused call
+		 * returns false — the caller treats it as a cancellation. The flag is thread_local (file dialogs
+		 * are shown from the UI thread) and RAII-scoped over the whole operation, including the inline
+		 * fallback path. */
+		static thread_local bool s_fileDialogActive = false;
+
+		if ( s_fileDialogActive )
+		{
+			TraceWarning{FileDialogClassId} << "Reentrant native file dialog ignored: one is already open on this thread.";
+
+			return false;
+		}
+
+		struct ActiveGuard final
+		{
+			ActiveGuard () noexcept { s_fileDialogActive = true; }
+			~ActiveGuard () { s_fileDialogActive = false; }
+			ActiveGuard (const ActiveGuard &) = delete;
+			ActiveGuard (ActiveGuard &&) = delete;
+			ActiveGuard & operator= (const ActiveGuard &) = delete;
+			ActiveGuard & operator= (ActiveGuard &&) = delete;
+		} activeGuard;
+
+		/* The dialog is OWNED by the real main window so the OS provides native modality (it disables
+		 * the owner), native centering (on the owner), and native Z-order (the dialog stays above the
+		 * owner and resurfaces with it on activation — e.g. after an alt-tab / taskbar click). Read
+		 * the owner + its DPI context on the CALLER thread; the worker only receives handles/ids by
+		 * value. When parentToWindow == false the owner is null: the dialog is shown ownerless —
+		 * no modality, no centering. The DPI context is replicated whenever a main window exists
+		 * (independent of parentToWindow) so even an ownerless dialog renders at the right scale. */
 		const HWND mainWindow = window.getWin32Window();
-		RECT ownerRect{};
-		const bool haveOwnerRect = parentToWindow && mainWindow != nullptr && IsIconic(mainWindow) == 0 && GetWindowRect(mainWindow, &ownerRect) != 0;
+		const HWND ownerWindow = parentToWindow ? mainWindow : nullptr;
+		const DWORD ownerThreadId = ownerWindow != nullptr ? GetWindowThreadProcessId(ownerWindow, nullptr) : 0;
 		const DPI_AWARENESS_CONTEXT dpiContext = mainWindow != nullptr ? GetWindowDpiAwarenessContext(mainWindow) : nullptr;
 
-		/* The actual dialog run: STA COM init + hidden centering owner + body, on whichever thread
-		 * invokes it (the dedicated worker normally, the caller thread on the fallback path). */
-		const auto runDialog = [&dialogBody, haveOwnerRect, &ownerRect] () -> bool {
+		/* The actual dialog run: STA COM init + body, on whichever thread invokes it (the dedicated
+		 * worker normally, the caller thread on the fallback path).
+		 *
+		 * The owner is CROSS-THREAD (dialog on the worker, owner on the main thread). That is safe
+		 * here because the caller pumps messages while waiting (below), so the owner's implicit
+		 * enable/disable/activation sends complete. AttachThreadInput merges the two threads' input
+		 * state for the dialog's lifetime so activation and focus return behave as if same-thread. */
+		const auto runDialog = [&dialogBody, ownerWindow, ownerThreadId] () -> bool {
 			const HRESULT comInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
 
-			/* RAII hidden owner, created and destroyed on the running thread. */
-			const CenteringOwner owner{haveOwnerRect ? &ownerRect : nullptr};
+			const bool inputAttached = ownerThreadId != 0 && AttachThreadInput(GetCurrentThreadId(), ownerThreadId, TRUE) != 0;
 
-			const bool dialogResult = dialogBody(owner.handle());
+			const bool dialogResult = dialogBody(ownerWindow);
+
+			if ( inputAttached )
+			{
+				AttachThreadInput(GetCurrentThreadId(), ownerThreadId, FALSE);
+			}
 
 			if ( SUCCEEDED(comInit) )
 			{
@@ -505,6 +478,74 @@ namespace EmEn::PlatformSpecific
 			TraceWarning{FileDialogClassId} << "Unable to spawn the dedicated dialog thread (" << error.what() << "); running the dialog inline.";
 
 			return runDialog();
+		}
+
+		/* Wait for the dialog WITHOUT hard-blocking the main thread — drain the caller's own message
+		 * queue, then block, repeat. Pumping is required for two reasons:
+		 *   1. The dialog owns the main window CROSS-THREAD, so the OS sends it WM_ENABLE / activation
+		 *      messages originating from the worker; a bare join() would never service them, deadlocking
+		 *      the native modal handshake.
+		 *   2. A thread that stops pumping is marked "Not Responding" by Windows after ~5 s (DWM ghost:
+		 *      greyed snapshot, spinning cursor), even though the dialog is alive on the worker.
+		 * The main window is disabled by the native modal (it is the owner), so the pumped input is
+		 * ignored — responsive but non-interactive, the correct modal behavior. A reentrant open from a
+		 * dispatched message is refused by the guard at the top of this function.
+		 *
+		 * This does NOT reintroduce the shell-pane perf storm: that was the DIALOG's modal loop pumping
+		 * heavy traffic. The dialog's loop runs on the worker; this pump only services the main thread's
+		 * own messages (paint, CEF, DWM pings). */
+		const HANDLE workerHandle = static_cast< HANDLE >(worker->native_handle());
+
+		for ( ;; )
+		{
+			/* Drain FIRST, then wait. Dispatch everything currently queued for THIS thread's own
+			 * windows (paint, posted CEF work, timers, WM_QUIT), then block. Draining before the wait
+			 * catches a WM_QUIT already sitting in the queue immediately, and removes the need for
+			 * MWMO_INPUTAVAILABLE — which, combined with the shared input queue (see the wait below),
+			 * is what caused the busy-spin. */
+			MSG message;
+			bool quitReceived = false;
+
+			while ( PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE) != 0 )
+			{
+				if ( message.message == WM_QUIT )
+				{
+					/* App is quitting. Stop pumping, wait the dialog out with a plain block (brief,
+					 * and only on this rare path), then re-post WM_QUIT so the engine's main loop
+					 * sees it after we return — we never return while the dialog is still up. */
+					WaitForSingleObject(workerHandle, INFINITE);
+					PostQuitMessage(static_cast< int >(message.wParam));
+					quitReceived = true;
+					break;
+				}
+
+				TranslateMessage(&message);
+				DispatchMessageW(&message);
+			}
+
+			if ( quitReceived )
+			{
+				break;
+			}
+
+			/* Wait for the worker to finish OR for work THIS thread must service. The wake mask
+			 * deliberately EXCLUDES QS_INPUT: AttachThreadInput (in runDialog) shares the worker's
+			 * input queue, so mouse-moves / keystrokes aimed at the DIALOG would otherwise wake this
+			 * wait continuously while the PeekMessage drain above — which only retrieves messages for
+			 * THIS thread's own windows — removes nothing, spinning at 100% CPU whenever the user
+			 * moves the mouse over the dialog. The main window is disabled by the modal and has no
+			 * input to process anyway; it only needs paint, posted (CEF), timer and sent messages.
+			 * MWMO_INPUTAVAILABLE is intentionally omitted (we drained first), so already-seen shared
+			 * input never forces an immediate return. Sent messages (the owner's WM_ENABLE /
+			 * activation handshake) are serviced regardless of the mask. */
+			const DWORD waitStatus = MsgWaitForMultipleObjectsEx(1, &workerHandle, INFINITE, QS_PAINT | QS_TIMER | QS_POSTMESSAGE | QS_SENDMESSAGE, 0);
+
+			/* WAIT_OBJECT_0 → worker finished; anything other than "a message is available" (or an
+			 * unexpected wait failure) → stop and let join() reap the worker. */
+			if ( waitStatus != WAIT_OBJECT_0 + 1 )
+			{
+				break;
+			}
 		}
 
 		worker->join();


### PR DESCRIPTION
# TECH-1927 — Boîtes de dialogue fichier Windows : latence & blocage du thread principal

## Problème

Sur Windows, les dialogues natifs `IFileOpenDialog` / `IFileSaveDialog` présentaient deux défauts liés au thread sur lequel tourne leur boucle modale :

1. **Latence 3–5 s** — exécutée sur le thread principal du moteur (qui pompe le rendu, l'input et CEF), la boucle modale du dialogue déclenche une re-résolution du volet de navigation du shell à chaque rafale de messages : des milliers de lookups `SyncRootManager` / known-folders redondants. Sur une machine dont les dossiers connus sont redirigés vers un cloud (OneDrive, défaut Windows), le dialogue mettait 3–5 s à apparaître. Invisible sur un poste de dev sans OneDrive → difficile à diagnostiquer.
2. **Thread principal bloqué** — l'exécution du dialogue sur un thread dédié imposait ensuite d'attendre sa fin ; un `join()` nu **hard-bloquait** le thread principal : deadlock du handshake modal cross-thread et fenêtre marquée « Ne répond pas » (ghost DWM) après ~5 s.

## Solution

Le dialogue tourne sur un **thread STA dédié** (file de messages vide → le volet du shell se résout une fois, ~140 ms, ×25 plus rapide). Le thread principal ne se bloque plus : le `join()` nu est remplacé par une **boucle de pompage de messages** intercalée avant lui, qui attend la fin du worker tout en restant responsive (paint, CEF, DWM), avec le dialogue **owned par la vraie fenêtre principale** pour retrouver la modalité, le centrage et le Z-order natifs.

## Implémentation

- **Thread STA + owner cross-thread** : le worker fait `CoInitializeEx(STA)`, exécute le corps COM du dialogue avec la fenêtre principale comme owner, et réplique le contexte DPI. La sécurité du owner cross-thread repose sur `AttachThreadInput` (fusion des états d'input le temps du dialogue) + le pompage côté appelant.
- **Attente responsive (drain-then-wait)** : le thread principal draine sa propre file (`PeekMessage`/`Dispatch`) puis bloque dans `MsgWaitForMultipleObjectsEx`, en boucle, jusqu'à ce que le **handle du worker soit signalé**. `WM_QUIT` est capté et re-posté pour que le shutdown ne survienne qu'après fermeture du dialogue. Le `join()` final subsiste **uniquement pour le reaping du `std::thread`** (obligatoire) : à ce point le worker est déjà terminé, il retourne instantanément — ce n'est plus une attente.
- **Protection anti busy-spin** : le wake mask **exclut `QS_INPUT`** et `MWMO_INPUTAVAILABLE` n'est pas utilisé. Sans ça, `AttachThreadInput` partageant la file d'input, les mouvements souris destinés au dialogue réveillaient le thread principal en continu alors que son `PeekMessage` ne pouvait rien retirer → 100 % CPU. La fenêtre principale étant désactivée par la modale, elle n'a aucun input à traiter ; les `SendMessage` (handshake `WM_ENABLE`/activation) restent servis quel que soit le mask.
- **Protection anti-réentrance** : le pompage ré-entre la `WndProc`, donc un message dispatché pourrait rouvrir un second dialogue fichier. C'est **refusé en tête de fonction** (drapeau `thread_local` RAII-scopé) : l'appel réentrant retourne `false` (annulation). Refuser l'*ouverture* est le seul correctif robuste — un dialogue imbriqué owned par la même fenêtre ferait `EnableWindow(owner, TRUE)` à sa fermeture (le disable/enable Win32 n'est **pas** ref-compté), réactivant la fenêtre principale sous la modale externe. Repli inline sur le thread appelant si le worker ne peut être créé.

## À préciser

- **Portée** : Windows uniquement (`OpenFile`/`SaveFile`) ; Linux (zenity/kdialog) et macOS (`NSOpenPanel`) inchangés. Machinerie factorisée dans `runFileDialogOnDedicatedThread()` (`PlatformSpecific/Helpers.{hpp,windows.cpp}`).
- **Prérequis architectural** : l'exclusion de `QS_INPUT` est sûre parce que CEF tourne en **windowless/OSR** (input injecté par le moteur, pas de fenêtre-enfant consommant du `WM_INPUT` sur le thread principal). À réévaluer si CEF repassait en rendu fenêtré.
- **Tradeoff assumé** : un 2ᵉ dialogue réentrant est traité comme annulé — sans impact réel (deux sélecteurs natifs empilés n'ont pas de sens, et les demandes IPC séquentielles ne sont pas réentrantes, la boucle moteur étant suspendue pendant l'appel).
- **Limite résiduelle mineure** : sous `parentToWindow == false` (dialogue sans owner, non utilisé par app_system), la fenêtre n'est pas désactivée ; une réentrance *non-fichier* reste théoriquement possible pendant le pump. Par ailleurs, une exception C++ qui remonterait d'une `WndProc` traverserait `DispatchMessageW` sous une fonction `noexcept` (contrainte Win32 pré-existante).
- **Documentation** : `src/PlatformSpecific/AGENTS.md` mis à jour (perf, owner-based modality/centering/Z-order, attente drain-then-wait, réentrance) ; commentaires inline des `execute()` réalignés.
