### PR TITLE
Window: the title bar follows the OS appearance, on the only platformthat allows it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,9 @@ if ( MSVC )
 
 	# Link Secur32 for GetUserNameExW (Extended Security API).
 	target_link_libraries(${PROJECT_NAME} PRIVATE Secur32)
+
+	# Link Dwmapi for DwmSetWindowAttribute (title bar light/dark appearance).
+	target_link_libraries(${PROJECT_NAME} PRIVATE Dwmapi)
 elseif ( APPLE )
 	message("[EmeraudeEngine] Configuring C++ compiler (>= AppleClang 17.0) for macOS ...")
 

--- a/src/SettingKeys.hpp
+++ b/src/SettingKeys.hpp
@@ -236,6 +236,9 @@ namespace EmEn
 			/* Create a borderless window (no OS title bar / decorations). */
 			constexpr auto WindowFramelessKey{"Core/Video/Window/Frameless"};
 			constexpr auto DefaultWindowFrameless{false};
+			/* Light/dark appearance of the OS title bar: "System" follows the OS preference, "Dark" and "Light" force it. */
+			constexpr auto WindowTitleBarThemeKey{"Core/Video/Window/TitleBarTheme"};
+			constexpr auto DefaultWindowTitleBarTheme{"System"};
 			/* Windowed-mode X position in pixels. */
 			constexpr auto WindowXPositionKey{"Core/Video/Window/XPosition"};
 			constexpr auto DefaultWindowXPosition{64};

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -303,6 +303,10 @@ namespace EmEn
 
 		this->initializeState(false);
 
+		/* NOTE: Applied while the window is still hidden, otherwise the OS shows the default
+		 * (light) title bar for a frame before repainting it. */
+		this->applyTitleBarTheme();
+
 		/* NOTE: The window starts non-visible. */
 		glfwShowWindow(m_handle.get());
 

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -703,6 +703,17 @@ namespace EmEn
 			void disableTitleBar () noexcept;
 
 			/**
+			 * @brief Applies the light/dark appearance of the OS title bar.
+			 * @note Driven by the "Core/Video/Window/TitleBarTheme" setting: "System" (default) follows
+			 * the OS light/dark preference, "Dark" and "Light" force it. Only the appearance is set,
+			 * the colors themselves stay the ones the OS theme dictates.
+			 * @note Implemented on Windows (DWM). No-op on macOS, where AppKit already follows the
+			 * system appearance, and on Linux, where the compositor owns the decorations.
+			 * @return void
+			 */
+			void applyTitleBarTheme () noexcept;
+
+			/**
 			 * @brief Returns the position, in screen coordinates of the window content area upper-left corner.
 			 * @param monitor A pointer to the monitor. Default primary.
 			 * @return std::array< int32_t, 2 >

--- a/src/Window.linux.cpp
+++ b/src/Window.linux.cpp
@@ -111,6 +111,12 @@ namespace EmEn
 
 	}
 
+	void
+	Window::applyTitleBarTheme () noexcept
+	{
+		// Nothing to do
+	}
+
 	bool
 	Window::initializeNativeWindow () noexcept
 	{

--- a/src/Window.mac.mm
+++ b/src/Window.mac.mm
@@ -96,6 +96,12 @@ namespace EmEn
 
 	}
 
+	void
+	Window::applyTitleBarTheme () noexcept
+	{
+		// Nothing to do
+	}
+
 	bool
 	Window::initializeNativeWindow () noexcept
 	{

--- a/src/Window.windows.cpp
+++ b/src/Window.windows.cpp
@@ -26,20 +26,66 @@
 
 #include "Window.hpp"
 
+/* STL inclusions. */
+#include <format>
+
 /* Third-party inclusions. */
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include "GLFW/glfw3native.h"
+#include <dwmapi.h>
 #include <shobjidl.h>
 #include <vulkan/vulkan_win32.h>
 
 /* Local inclusions. */
+#include "PrimaryServices.hpp"
+#include "SettingKeys.hpp"
 #include "Tracer.hpp"
 #include "Vulkan/Instance.hpp"
 #include "Vulkan/Utility.hpp"
 
 namespace EmEn
 {
+	using namespace Base;
 	using namespace Vulkan;
+
+	namespace
+	{
+		/* DWMWA_USE_IMMERSIVE_DARK_MODE, documented since Windows 10 2004 (and Windows 11). */
+		constexpr DWORD DarkModeAttribute{20};
+		/* The same semantics under a different index on Windows 10 1809/1903. */
+		constexpr DWORD LegacyDarkModeAttribute{19};
+
+		/**
+		 * @brief Reads the OS-wide light/dark preference applications are asked to follow.
+		 * @note This is the value the Windows "Choose your mode" personalization setting writes.
+		 * @return bool True when the OS asks for a dark appearance.
+		 */
+		[[nodiscard]]
+		bool
+		isSystemUsingDarkAppearance () noexcept
+		{
+			DWORD appsUseLightTheme{1};
+			DWORD dataSize{sizeof(appsUseLightTheme)};
+
+			const auto result = RegGetValueW(
+				HKEY_CURRENT_USER,
+				L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+				L"AppsUseLightTheme",
+				RRF_RT_REG_DWORD,
+				nullptr,
+				&appsUseLightTheme,
+				&dataSize
+			);
+
+			/* NOTE: The value is absent on systems that never had a dark appearance, which is a light system. */
+			if ( result != ERROR_SUCCESS )
+			{
+				return false;
+			}
+
+			return appsUseLightTheme == 0;
+		}
+	}
 
 	bool
 	Window::createSurface (bool useNativeCode) noexcept
@@ -101,6 +147,68 @@ namespace EmEn
 	Window::disableTitleBar () noexcept
 	{
 
+	}
+
+	void
+	Window::applyTitleBarTheme () noexcept
+	{
+		if ( m_handle == nullptr )
+		{
+			return;
+		}
+
+		auto * hwnd = glfwGetWin32Window(m_handle.get());
+
+		if ( hwnd == nullptr )
+		{
+			Tracer::warning(ClassId, "Unable to get the Win32 window handle, the title bar keeps the default appearance.");
+
+			return;
+		}
+
+		const auto theme = String::toLower(m_primaryServices.settings().getOrSetDefault< std::string >(WindowTitleBarThemeKey, DefaultWindowTitleBarTheme));
+
+		bool useDarkAppearance = false;
+
+		if ( theme == "dark" )
+		{
+			useDarkAppearance = true;
+		}
+		else if ( theme == "light" )
+		{
+			useDarkAppearance = false;
+		}
+		else
+		{
+			if ( theme != "system" )
+			{
+				TraceWarning{ClassId} << "Unknown '" << WindowTitleBarThemeKey << "' value '" << theme << "', falling back to 'System'. Valid values are 'System', 'Dark' and 'Light'.";
+			}
+
+			useDarkAppearance = isSystemUsingDarkAppearance();
+		}
+
+		const BOOL attributeValue{useDarkAppearance ? TRUE : FALSE};
+
+		auto result = DwmSetWindowAttribute(hwnd, DarkModeAttribute, &attributeValue, sizeof(attributeValue));
+
+		/* NOTE: Windows 10 1809/1903 only knows the legacy index. */
+		if ( FAILED(result) )
+		{
+			result = DwmSetWindowAttribute(hwnd, LegacyDarkModeAttribute, &attributeValue, sizeof(attributeValue));
+		}
+
+		if ( FAILED(result) )
+		{
+			TraceWarning{ClassId} << "This system does not support a themed title bar (DwmSetWindowAttribute returned " << std::format("0x{:08X}", static_cast< uint32_t >(result)) << "), keeping the default appearance.";
+
+			return;
+		}
+
+		if ( this->showInformation() )
+		{
+			TraceInfo{ClassId} << "Title bar appearance set to " << ( useDarkAppearance ? "dark" : "light" ) << " (setting '" << WindowTitleBarThemeKey << "' is '" << theme << "').";
+		}
 	}
 
 	bool


### PR DESCRIPTION
New setting "Core/Video/Window/TitleBarTheme": "System" (default) follows the OS light/dark preference, "Dark" and "Light" force it. Only the *appearance* is set — the colors stay the ones the OS theme dictates.

Windows: DwmSetWindowAttribute with DWMWA_USE_IMMERSIVE_DARK_MODE (index 20, falling back to the legacy index 19 on Windows 10 1809/1903); a system too old for either traces a warning and keeps the default appearance. "System" reads the personalization value HKCU\...\Themes\Personalize\AppsUseLightTheme. Dwmapi is linked on MSVC.

Applied while the window is still hidden, before glfwShowWindow(): otherwise the OS presents the default light bar for a frame, and Windows 10 does not reliably repaint the non-client area afterwards without forcing a SWP_FRAMECHANGED.

applyTitleBarTheme() is declared, defined AND called under #if IS_WINDOWS. There is deliberately no macOS/Linux implementation, not even an empty one: an AppKit window already follows the system appearance, and on Linux the compositor (Mutter, KWin) or libdecor owns the decorations and paints them with the user's desktop theme, with no cross-desktop per-window override. Both files carry a NOTE stating why, and the macOS one keeps the NSAppearance path as a TODO for an explicit Dark/Light override.

Not applied live: toggling the OS theme while the app runs needs a restart, since reacting to WM_SETTINGCHANGE/ImmersiveColorSet would first mean re-enabling the currently commented-out Window::windowProc() subclass.