### PR TITLE
MSVC export: explicit copy/move deletes on ProbeConvolver, finish the EMEN_API rename

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ pulled in by `cmake/InstallEmeraudeBase.cmake` (clone-if-absent + `add_subdirect
 > `WINDOWS_EXPORT_ALL_SYMBOLS` + PCH incompatibility (PCH marker symbols leaking into the
 > auto-generated `exports.def` → `LNK2001`) was fixed by completing the explicit-export
 > migration — `EMERAUDE_USE_EXPLICIT_EXPORTS` defaults to **On**, the public surface consumed
-> by a consumer application carries `EMERAUDE_API`, and C4251/C4275 are disabled cascade-wide (decision
+> by a consumer application carries `EMEN_API`, and C4251/C4275 are disabled cascade-wide (decision
 > "2b": emeraude-base types stay unexported, consumers keep their static base copy). Full MSVC
 > cascade verified (build + link with PCH). **macOS Objective-C++ is handled (2026-07):** the
 > base helper auto-sets `SKIP_PRECOMPILE_HEADERS` on the engine's `.mm` sources (SerialPort,
@@ -297,7 +297,7 @@ how to add new commands.
 -   **Pipeline Caching:** [`docs/pipeline-caching-system.md`](docs/pipeline-caching-system.md) (Critical for render pass compatibility).
 -   **Runtime Session:** [`docs/runtime-session.md`](docs/runtime-session.md) (Launch, connect, interact with a running instance).
 -   **Toolkit:** [`docs/toolkit-system.md`](docs/toolkit-system.md) (Scene construction helper — the fast way to build scenes vs manual Scene API).
--   **Windows Export API:** [`docs/windows-export-api.md`](docs/windows-export-api.md) (`EMERAUDE_API` migration — required on MSVC with PCH; in progress).
+-   **Windows Export API:** [`docs/windows-export-api.md`](docs/windows-export-api.md) (`EMEN_API` migration — required on MSVC with PCH; in progress).
 
 > [!CRITICAL]
 > **Maintenance:** AI documentation is **MORE IMPORTANT than the code itself.** A code change

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,10 +72,10 @@ option(EMERAUDE_ENABLE_LSAN "Enable 'LeakSanitizer' library. Adds a dev tool to 
 option(EMERAUDE_ENABLE_TSAN "Enable 'ThreadSanitizer' library. Adds a dev tool to detects data race [SYSTEM] (Linux only, Default Off)." Off)
 option(EMERAUDE_ENABLE_UBSAN "Enable 'UndefinedBehaviorSanitizer' library. Adds a dev tool to detects undefined behavior [SYSTEM] (Linux only, Default Off)." Off)
 option(EMERAUDE_ENABLE_IMGUI "Enable 'libimgui' library. Adds a GUI to the engine [LOCAL] (Default Off)." Off)
-# Explicit DLL export API: drop WINDOWS_EXPORT_ALL_SYMBOLS in favour of the EMERAUDE_API macro
+# Explicit DLL export API: drop WINDOWS_EXPORT_ALL_SYMBOLS in favour of the EMEN_API macro
 # (emeraude_export.hpp). Required on MSVC once the PCH is enabled — auto-generated exports.def
 # leaks PCH marker symbols and fails to link. See docs/windows-export-api.md.
-option(EMERAUDE_USE_EXPLICIT_EXPORTS "Use the explicit EMERAUDE_API export macro instead of WINDOWS_EXPORT_ALL_SYMBOLS (Default On)." On)
+option(EMERAUDE_USE_EXPLICIT_EXPORTS "Use the explicit EMEN_API export macro instead of WINDOWS_EXPORT_ALL_SYMBOLS (Default On)." On)
 # Debug preprocessor macros control (Ignored in Release).
 option(EMERAUDE_DEBUG_KEYBOARD_INPUT "Enable printing of events to the console from keyboard inputs (Default Off)." Off)
 option(EMERAUDE_DEBUG_POINTER_INPUT "Enable printing of events to the console from pointer inputs (Default Off)." Off)
@@ -201,9 +201,9 @@ emeraude_base_target_enable_pch(${PROJECT_NAME})
 
 # Public DLL boundary — see docs/windows-export-api.md.
 #  - EMERAUDE_USE_EXPLICIT_EXPORTS=OFF (default): WINDOWS_EXPORT_ALL_SYMBOLS produces the export set;
-#    the EMERAUDE_API macro (emeraude_export.hpp) is a no-op, so the public API can be annotated
+#    the EMEN_API macro (emeraude_export.hpp) is a no-op, so the public API can be annotated
 #    class-by-class without ever breaking the build.
-#  - ON: EMERAUDE_API drives __declspec(dllexport/import) and WINDOWS_EXPORT_ALL_SYMBOLS is dropped.
+#  - ON: EMEN_API drives __declspec(dllexport/import) and WINDOWS_EXPORT_ALL_SYMBOLS is dropped.
 #    Required on MSVC once the PCH is enabled.
 if ( EMERAUDE_USE_EXPLICIT_EXPORTS )
 	set(EMERAUDE_WINDOWS_EXPORT_ALL OFF)

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ For a debug build, swap `Release` → `Debug` everywhere (build directory, `CMAK
 | `EMERAUDE_BUILD_SERVICES_ONLY` | `Off` | Build the engine services without the rendering stack. |
 | `EMERAUDE_ENABLE_IMGUI` | `Off` | Compile the ImGui debug UI. |
 | `EMERAUDE_ENABLE_RENDERDOC` | `Off` | RenderDoc in-application API (see below). |
-| `EMERAUDE_USE_EXPLICIT_EXPORTS` | `On` | Windows: explicit `EMERAUDE_API` export macro instead of `WINDOWS_EXPORT_ALL_SYMBOLS`. See [`docs/windows-export-api.md`](docs/windows-export-api.md). |
+| `EMERAUDE_USE_EXPLICIT_EXPORTS` | `On` | Windows: explicit `EMEN_API` export macro instead of `WINDOWS_EXPORT_ALL_SYMBOLS`. See [`docs/windows-export-api.md`](docs/windows-export-api.md). |
 | `EMERAUDE_USE_STATIC_RUNTIME` | `Off` | Windows: static MSVC runtime (`/MT`). Also selects the matching prebuilt archive. |
 | `EMERAUDE_ENABLE_ASAN` / `MSAN` / `LSAN` / `TSAN` / `UBSAN` | `Off` | Sanitizers (Linux only). |
 | `EMERAUDE_DEBUG_KEYBOARD_INPUT`, `EMERAUDE_DEBUG_POINTER_INPUT`, `EMERAUDE_DEBUG_WINDOW_EVENTS`, `EMERAUDE_DEBUG_VULKAN_TRACKING` | `Off` | Console tracing of the matching subsystem. |

--- a/docs/windows-export-api.md
+++ b/docs/windows-export-api.md
@@ -1,10 +1,10 @@
-# Windows DLL export API (`EMERAUDE_API`) — migration guide
+# Windows DLL export API (`EMEN_API`) — migration guide
 
 > Status: **migration complete (2026-07).** `EMERAUDE_USE_EXPLICIT_EXPORTS` defaults to **ON**
-> (explicit `EMERAUDE_API` boundary, `WINDOWS_EXPORT_ALL_SYMBOLS` dropped) and
+> (explicit `EMEN_API` boundary, `WINDOWS_EXPORT_ALL_SYMBOLS` dropped) and
 > `EMERAUDE_ENABLE_PCH` defaults to **ON**. The full MSVC cascade (base → engine → a consumer library →
 > consumer executables) builds and links with the PCH enabled. New public API that a consumer
-> references out-of-line must carry `EMERAUDE_API` — the consumer's linker (`LNK2019` on
+> references out-of-line must carry `EMEN_API` — the consumer's linker (`LNK2019` on
 > `__imp_...`) names any omission.
 
 ## 1. Why this exists
@@ -24,13 +24,13 @@ Emeraude.lib : fatal error LNK1120: 1 unresolved externals
 ```
 
 GCC/Clang are unaffected (no `.def`; ELF/Mach-O export via symbol visibility). The fix is to stop
-auto-exporting and declare the public boundary explicitly with the `EMERAUDE_API` macro.
+auto-exporting and declare the public boundary explicitly with the `EMEN_API` macro.
 
 ## 2. The toggle
 
 `option(EMERAUDE_USE_EXPLICIT_EXPORTS … OFF)` in `CMakeLists.txt`:
 
-| Mode | `WINDOWS_EXPORT_ALL_SYMBOLS` | `EMERAUDE_API` expands to |
+| Mode | `WINDOWS_EXPORT_ALL_SYMBOLS` | `EMEN_API` expands to |
 |------|------------------------------|---------------------------|
 | **OFF** (default) | `ON` | *nothing* (no-op) |
 | **ON** | `OFF` | `__declspec(dllexport)` while building the DLL (`Emeraude_EXPORTS` is auto-defined by CMake for the SHARED target), `__declspec(dllimport)` for consumers, `__attribute__((visibility("default")))` elsewhere |
@@ -41,16 +41,16 @@ referenced surface is annotated. The macro lives in [`src/emeraude_export.hpp`](
 
 ## 3. What to annotate
 
-`EMERAUDE_API` marks the boundary of what crosses the DLL edge and is referenced **out-of-line** by
+`EMEN_API` marks the boundary of what crosses the DLL edge and is referenced **out-of-line** by
 a consumer (`projet-alpha`, tests, tools).
 
 - **Annotate**: a public `class`/`struct` that has out-of-line member definitions (i.e. a `.cpp`).
-  Put it on the type — `class EMERAUDE_API Foo` — which exports every member.
+  Put it on the type — `class EMEN_API Foo` — which exports every member.
   ```cpp
   #include "emeraude_export.hpp"
 
-  class EMERAUDE_API Foo { … };
-  EMERAUDE_API bool freeFunction (int);   // out-of-line free function
+  class EMEN_API Foo { … };
+  EMEN_API bool freeFunction (int);   // out-of-line free function
   ```
 - **Do NOT annotate**: header-only / fully-inline classes, function/class **templates** (instantiated
   in the consumer — `Math/*`, most of `Base::PixelFactory`), `constexpr`/`inline` helpers, and
@@ -64,7 +64,7 @@ emeraude-base's `EMERAUDE_COMPILE_OPTIONS`) rather than driving an annotation ca
 
 - The whole cascade (DLL + every consumer) is built with the **same toolchain and CRT** — the
   layout/allocator mismatches those warnings guard against cannot occur.
-- `EMERAUDE_API` classes may derive from emeraude-base traits that stay unexported **by design**
+- `EMEN_API` classes may derive from emeraude-base traits that stay unexported **by design**
   (see § 4). Annotating the base hierarchy would only serve the warning, not a real need.
 
 Consequence: annotating a class does **not** pull in its bases. Annotate only what the linker
@@ -100,7 +100,7 @@ build** and draining the linker:
    a Claude-owned build dir (never the CLion `cmake-build-*`).
 2. Build the cascade; the consumer's link reports `LNK2019` (unresolved import) for every
    not-yet-exported symbol it references.
-3. For each, annotate the **owning class/function** with `EMERAUDE_API` (bases are NOT pulled in —
+3. For each, annotate the **owning class/function** with `EMEN_API` (bases are NOT pulled in —
    C4275 is disabled, see § 3).
 4. Repeat until the link is green. Then make `EMERAUDE_USE_EXPLICIT_EXPORTS=ON` the default and drop
    this guidance to a short "done" note.
@@ -110,7 +110,7 @@ minimal and intentional.
 
 ## 6. Exported pimpl — out-of-line destructors, and the header hygiene it unlocks
 
-An `EMERAUDE_API`-exported class forces MSVC to instantiate its **destructor at the class
+An `EMEN_API`-exported class forces MSVC to instantiate its **destructor at the class
 definition point in every TU**. If such a class holds a `std::unique_ptr< T >` to a
 forward-declared (incomplete) `T`, `= default`-ing the destructor in the header instantiates
 `std::default_delete< T >` on an incomplete type → hard error. The fix is the **exported pimpl**
@@ -119,7 +119,7 @@ complete.
 
 ```cpp
 // Foo.hpp
-class EMERAUDE_API Foo final
+class EMEN_API Foo final
 {
     public:
         ~Foo ();                       // declared only — NOT '= default'
@@ -132,7 +132,8 @@ class EMERAUDE_API Foo final
 Foo::~Foo () = default;                // deleter sees the complete Bar here
 ```
 
-Current users: `Graphics::Renderer`, `Graphics::PostProcessor`, `Graphics::BindlessTextureManager`.
+Current users: `Graphics::Renderer`, `Graphics::PostProcessor`, `Graphics::BindlessTextureManager`,
+`Graphics::Compute::ProbeConvolver`.
 
 **The lever this unlocks.** Once the destructor is out-of-line, *every* smart-pointer and
 reference member may point at an incomplete type, so a hot header can trade `#include` for
@@ -187,6 +188,62 @@ delta per TU, and that part is reliable: it is how the 2026-07 pass found `Graph
 > **Lesson: validate a detector against a known-broken TU before trusting its silence.** Only the
 > header-level delta is sound enough to bound the surface; for the rest, **let the compiler
 > enumerate it** and budget several build rounds.
+
+### Same mechanism, other special members — delete copy explicitly on move-only holders
+
+The destructor is not the only implicit member the export materializes: MSVC defines **every**
+implicitly-declared special member of an exported class at its definition point. So an exported
+class holding a move-only member (`std::unique_ptr`, or a container of them) must **delete its
+copy operations explicitly** — leaving them implicit is not equivalent.
+
+Why "implicit" is not enough here: an implicit copy assignment is defined as deleted only when a
+member's own copy assignment is *deleted or inaccessible*. `std::vector::operator=(const vector&)`
+is neither — it is declared for **any** `T`, move-only included, and is not SFINAE-constrained. It
+is merely ill-formed **in its body**. The class's copy assignment is therefore a normal (non-deleted)
+implicit member, the export forces its definition, and the error lands deep inside
+`std::vector::_Assign_counted_range` on `std::unique_ptr::operator=(const unique_ptr &)`:
+
+```
+vector(1461): error C2280: 'std::unique_ptr<T> &std::unique_ptr<T>::operator =(const std::unique_ptr<T> &)':
+              attempting to reference a deleted function
+  ProbeConvolver.hpp(130): see reference to class template instantiation 'std::vector<std::unique_ptr<T>>'
+  ProbeConvolver.hpp(138): see the first reference to 'std::vector<...>::operator =' in 'ProbeConvolver::operator ='
+```
+
+Read that trace carefully: the "first reference" points at the class's **closing brace** — the
+implicit-definition location — not at any call site. **Nothing in the codebase copies the class**;
+the export alone is enough.
+
+```cpp
+class EMEN_API ProbeConvolver final
+{
+    public:
+        ProbeConvolver () noexcept = default;
+        ProbeConvolver (const ProbeConvolver &) = delete;              // required by the export
+        ProbeConvolver (ProbeConvolver &&) = delete;                   // already suppressed by the dtor
+        ProbeConvolver & operator= (const ProbeConvolver &) = delete;  // required by the export
+        ProbeConvolver & operator= (ProbeConvolver &&) = delete;
+        ~ProbeConvolver () noexcept;                                   // out of line (exported pimpl)
+    private:
+        std::vector< std::unique_ptr< Vulkan::DescriptorSet > > m_mipDescriptorSets;
+};
+```
+
+The move operations were already suppressed by the user-declared destructor, so deleting them
+changes no contract — declare them anyway: it is the style of every other exported RAII holder
+(`MDI::BatchBuilder`, `Scenes::SceneMetaData`, `Scenes::SceneInstanceTransforms`, …), and it turns
+`ProbeConvolver a = std::move(b);` into an error that names the move instead of one that names the
+deleted copy overload it silently fell back to.
+
+What immunizes a class is having **any base or member whose copy assignment is genuinely deleted** —
+the class's own is then deleted too, and a deleted member is never defined. That covers most engine
+services (non-copyable base), but also, *by accident*, some standalone holders:
+`Graphics::SharedUniformBuffer` is exported, standalone, and holds two
+`std::vector< std::unique_ptr< … > >` — yet never trips this, only because of its
+`mutable std::mutex` member. Do not read that silence as "a vector of `unique_ptr` is fine here".
+
+The genuinely exposed case is the standalone exported RAII holder with no such member:
+`Graphics::Compute::ProbeConvolver` was the first (2026-08).
 
 ## 7. Status
 

--- a/src/Graphics/Compute/ProbeConvolver.hpp
+++ b/src/Graphics/Compute/ProbeConvolver.hpp
@@ -82,6 +82,36 @@ namespace EmEn::Graphics::Compute
 			ProbeConvolver () noexcept = default;
 
 			/**
+			 * @brief Copy constructor (deleted).
+			 * @note Deleted EXPLICITLY, not merely left implicit: the class is exported
+			 * (EMEN_API), which forces MSVC to DEFINE every implicit special member at the
+			 * class definition point. The implicit copy assignment is not deleted (std::vector's
+			 * copy assignment is declared for any T, move-only included — it is only ill-formed
+			 * in its body), so defining it hard-errors on m_mipDescriptorSets
+			 * (std::unique_ptr is not copy-assignable). Same export mechanism as the out-of-line
+			 * destructor of BindlessTextureManager. See docs/windows-export-api.md.
+			 */
+			ProbeConvolver (const ProbeConvolver &) = delete;
+
+			/**
+			 * @brief Move constructor (deleted).
+			 * @note Already suppressed by the user-declared destructor — explicit for the
+			 * diagnostic and for consistency with the other exported RAII holders.
+			 */
+			ProbeConvolver (ProbeConvolver &&) = delete;
+
+			/**
+			 * @brief Copy assignment (deleted).
+			 * @note See the copy constructor — this is the member the export actually chokes on.
+			 */
+			ProbeConvolver & operator= (const ProbeConvolver &) = delete;
+
+			/**
+			 * @brief Move assignment (deleted).
+			 */
+			ProbeConvolver & operator= (ProbeConvolver &&) = delete;
+
+			/**
 			 * @brief Destructs the probe convolver.
 			 * @note Out of line: members are smart pointers to forward-declared types.
 			 */

--- a/src/Overlay/FramebufferProperties.cpp
+++ b/src/Overlay/FramebufferProperties.cpp
@@ -65,7 +65,7 @@ namespace EmEn::Overlay
 		m_resolutionY = 0.0F;
 	}
 
-	/* NOTE: EMERAUDE_API is carried by both header declarations (the in-class 'friend' and the
+	/* NOTE: EMEN_API is carried by both header declarations (the in-class 'friend' and the
 	 * one below the class); this definition repeats it so all three agree on linkage. Omitting it
 	 * anywhere warns C4273 on consumers. See docs/windows-export-api.md § "friend operator<<". */
 	EMEN_API std::ostream &

--- a/src/emeraude_export.hpp
+++ b/src/emeraude_export.hpp
@@ -27,24 +27,25 @@
 #pragma once
 
 /*
- * EMERAUDE_API — public boundary annotation for the engine shared library (Emeraude.dll).
+ * EMEN_API — public boundary annotation for the engine shared library (Emeraude.dll).
  * See docs/windows-export-api.md for the full migration procedure and rationale.
  *
  * Two modes, selected by the EMERAUDE_USE_EXPLICIT_EXPORTS build option (CMake):
  *
- *  - OFF (default): the macro expands to NOTHING. The DLL's exported surface is produced by
- *    CMake's WINDOWS_EXPORT_ALL_SYMBOLS, exactly as before. Annotations are harmless no-ops,
- *    so the public API can be migrated class-by-class without ever breaking the build.
+ *  - ON (default since the migration completed, 2026-07): the macro becomes
+ *    __declspec(dllexport) while building the DLL (CMake auto-defines Emeraude_EXPORTS for the
+ *    SHARED target) and __declspec(dllimport) for consumers (projet-alpha);
+ *    WINDOWS_EXPORT_ALL_SYMBOLS is dropped. This is the end state required on MSVC, where
+ *    WINDOWS_EXPORT_ALL_SYMBOLS + precompiled headers leak PCH marker symbols into the
+ *    auto-generated exports.def and fail to link (LNK2001 on a bogus '__' symbol).
  *
- *  - ON: the macro becomes __declspec(dllexport) while building the DLL (CMake auto-defines
- *    Emeraude_EXPORTS for the SHARED target) and __declspec(dllimport) for consumers
- *    (projet-alpha); WINDOWS_EXPORT_ALL_SYMBOLS is dropped. This is the end state required on
- *    MSVC, where WINDOWS_EXPORT_ALL_SYMBOLS + precompiled headers leak PCH marker symbols into
- *    the auto-generated exports.def and fail to link (LNK2001 on a bogus '__' symbol).
+ *  - OFF: the macro expands to NOTHING. The DLL's exported surface is produced by CMake's
+ *    WINDOWS_EXPORT_ALL_SYMBOLS, as before the migration. Annotations are harmless no-ops —
+ *    this was the staged path that let the public API be annotated class-by-class.
  *
- * Annotate public CLASSES (exports every member) and out-of-line free functions with
- * EMERAUDE_API. A dll-interface class whose base is not itself EMERAUDE_API triggers C4275 on
- * MSVC — its bases must be annotated too (see the doc).
+ * Annotate public CLASSES (exports every member) and out-of-line free functions with EMEN_API.
+ * Annotating a class does NOT pull in its bases: C4275/C4251 are disabled cascade-wide by
+ * decision (same toolchain and CRT everywhere), so annotate only what the linker names.
  */
 #if defined(EMERAUDE_USE_EXPLICIT_EXPORTS)
 	#if defined(_WIN32) || defined(__CYGWIN__)


### PR DESCRIPTION
An EMEN_API class gets EVERY implicit special member defined at its definition point, not just the destructor. ProbeConvolver holds a std::vector<std::unique_ptr<DescriptorSet>>, so the export alone hard-errored on the implicit copy assignment (std::vector's is declared for any T and only ill-formed in its body, hence not deleted). All four are now deleted, like every other exported RAII holder.

Documented in docs/windows-export-api.md § 6: what immunizes a class is any base or member whose copy assignment is genuinely deleted — SharedUniformBuffer escapes it only thanks to its mutable std::mutex.

Collateral: the EMERAUDE_API -> EMEN_API rename (c29b39cf) had never reached the prose. Swept doc, AGENTS.md, README.md and the CMake/header comments — including emeraude_export.hpp, which still announced OFF as the default and still required annotating base classes.