### PR TITLE
SystemNotification: delegate the permission to the OS

### DIFF
--- a/src/Core.hpp
+++ b/src/Core.hpp
@@ -1703,7 +1703,7 @@ namespace EmEn
 			Audio::Manager m_audioManager{m_primaryServices, m_resourceManager};	   ///< OpenAL audio system.
 			Overlay::Manager m_overlayManager{m_primaryServices, m_resourceManager}; ///< ImGui overlay system.
 			Notifier m_notifier{m_overlayManager};				  ///< On-screen notifications.
-			SystemNotification m_systemNotification{m_primaryServices.settings(), m_window};	  ///< OS-level system notifications.
+			SystemNotification m_systemNotification{m_window};	  ///< OS-level system notifications.
 			Scenes::Manager m_sceneManager{m_primaryServices, m_resourceManager, m_inputManager, m_notifier}; ///< Scene graph management.
 			/* Reusable capture buffer for screenshots. */
 			std::array< Base::PixelFactory::Pixmap< uint8_t >, 3 > m_screenshotImages{};

--- a/src/SettingKeys.hpp
+++ b/src/SettingKeys.hpp
@@ -50,9 +50,6 @@ namespace EmEn
 #elif IS_MACOS
 	constexpr auto DefaultTextEditor{"TextEdit"};
 #endif
-	/* System notification permission policy. Values: "allow", "deny", "ask" (default). */
-	constexpr auto CorePermissionsNotificationsKey{"Core/Permissions/Notifications"};
-	constexpr auto DefaultCorePermissionsNotifications{"ask"};
 
 		/* Tracer */
 		/* Restrict console tracing to errors and fatal messages only. */

--- a/src/SystemNotification.cpp
+++ b/src/SystemNotification.cpp
@@ -27,10 +27,7 @@
 #include "SystemNotification.hpp"
 
 /* Local inclusions. */
-#include "PlatformSpecific/Desktop/Dialog/Message.hpp"
 #include "PlatformSpecific/Desktop/Notification.hpp"
-#include "SettingKeys.hpp"
-#include "Settings.hpp"
 #include "Tracer.hpp"
 
 namespace EmEn
@@ -51,59 +48,33 @@ namespace EmEn
 		return true;
 	}
 
-	bool
+	NotificationPermission
+	SystemNotification::permissionStatus () const noexcept
+	{
+		if ( !this->usable() )
+		{
+			Tracer::warning(ClassId, "Cannot read the permission: service not initialized.");
+
+			return NotificationPermission::Denied;
+		}
+
+		/* TODO: macOS, query UNUserNotificationCenter. No other OS gates notifications. */
+		return NotificationPermission::Granted;
+	}
+
+	NotificationPermission
 	SystemNotification::requestPermission () const noexcept
 	{
-		using namespace PlatformSpecific::Desktop;
-
 		if ( !this->usable() )
 		{
 			Tracer::warning(ClassId, "Cannot request permission: service not initialized.");
 
-			return false;
+			return NotificationPermission::Denied;
 		}
 
-		/* Read current permission. */
-		const auto permission = m_settings.get< std::string >(CorePermissionsNotificationsKey, DefaultCorePermissionsNotifications);
-
-		/* Already granted. */
-		if ( permission == "allow" )
-		{
-			return true;
-		}
-
-		/* Already denied. */
-		if ( permission == "deny" )
-		{
-			return false;
-		}
-
-		/* Permission is "ask" - show dialog. */
-		Tracer::info(ClassId, "Showing notification permission dialog...");
-
-		Dialog::Message dialog{
-			"Notification Permission",
-			"This application wants to show desktop notifications.\n\nDo you want to allow notifications?",
-			Dialog::ButtonLayout::YesNo,
-			Dialog::MessageType::Question
-		};
-
-		dialog.execute(m_window, false);
-
-		if ( dialog.getUserAnswer() == Dialog::Answer::Yes )
-		{
-			m_settings.set< std::string >(CorePermissionsNotificationsKey, "allow");
-
-			Tracer::info(ClassId, "User granted notification permission.");
-
-			return true;
-		}
-
-		m_settings.set< std::string >(CorePermissionsNotificationsKey, "deny");
-
-		Tracer::info(ClassId, "User denied notification permission.");
-
-		return false;
+		/* TODO: macOS, request through UNUserNotificationCenter. No other OS gates notifications. */
+		/* NOTE: requestAuthorization() answers later, so this signature will need a callback. */
+		return NotificationPermission::Granted;
 	}
 
 	bool
@@ -116,7 +87,6 @@ namespace EmEn
 			return false;
 		}
 
-		/* Validate input parameters. */
 		if ( title.empty() )
 		{
 			Tracer::warning(ClassId, "Cannot show notification: title is empty.");
@@ -124,29 +94,14 @@ namespace EmEn
 			return false;
 		}
 
-		/* Check/request permission. */
-		const auto permission = m_settings.get< std::string >(CorePermissionsNotificationsKey, DefaultCorePermissionsNotifications);
-
-		if ( permission == "deny" )
+		if ( this->permissionStatus() != NotificationPermission::Granted )
 		{
-			Tracer::info(ClassId, "Notification blocked: permission denied.");
+			Tracer::info(ClassId, "Notification blocked: not authorized by the operating system.");
 
 			return false;
 		}
 
-		if ( permission == "ask" )
-		{
-			/* Request permission first. */
-			if ( !this->requestPermission() )
-			{
-				/* User denied permission. */
-				return false;
-			}
-		}
-
-		/* Permission is "allow" - show notification. */
 		PlatformSpecific::Desktop::Notification notification{&m_window, title, message, icon};
-
 		return notification.show();
 	}
 }

--- a/src/SystemNotification.hpp
+++ b/src/SystemNotification.hpp
@@ -30,6 +30,7 @@
 #include "emeraude_export.hpp"
 
 /* STL inclusions. */
+#include <cstdint>
 #include <optional>
 #include <string>
 
@@ -41,7 +42,6 @@
 
 namespace EmEn
 {
-	class Settings;
 	class Window;
 }
 
@@ -50,11 +50,19 @@ namespace EmEn
 	/** @brief Alias for notification icon from PlatformSpecific::Desktop. */
 	using NotificationIcon = PlatformSpecific::Desktop::NotificationIcon;
 
+	/** @brief The OS-level notification authorization status. */
+	enum class NotificationPermission : uint8_t
+	{
+		NotDetermined,
+		Granted,
+		Denied
+	};
+
 	/**
 	 * @brief The system notification service.
 	 * @note This service provides cross-platform OS-level notifications (system tray notifications).
 	 * @note Uses portable-file-dialogs library for cross-platform support.
-	 * @note Permission is managed via Settings with key "Notifications/Permission".
+	 * @note Permission is asked to the operating system, never persisted.
 	 * @extends EmEn::ServiceInterface This is a service.
 	 */
 	class EMEN_LEAN_API SystemNotification final : public ServiceInterface
@@ -66,13 +74,11 @@ namespace EmEn
 
 			/**
 			 * @brief Constructs the system notification service.
-			 * @param settings A reference to the application settings.
 			 * @param window A reference to the parent window.
 			 */
 			explicit
-			SystemNotification (Settings & settings, Window & window) noexcept
+			SystemNotification (Window & window) noexcept
 				: ServiceInterface{ClassId},
-				m_settings{settings},
 				m_window{window}
 			{
 
@@ -80,8 +86,7 @@ namespace EmEn
 
 			/**
 			 * @brief Shows a system notification.
-			 * @note If permission is "ask", shows a permission dialog first.
-			 * @note If permission is "deny", does nothing and returns false.
+			 * @note Returns false unless the OS already authorized notifications; never asks for it.
 			 * @param title The notification title.
 			 * @param message The notification message body.
 			 * @param icon The notification icon type. Default none (no icon).
@@ -91,13 +96,18 @@ namespace EmEn
 			bool show (const std::string & title, const std::string & message, std::optional< NotificationIcon > icon = std::nullopt) const noexcept;
 
 			/**
-			 * @brief Requests notification permission from the user.
-			 * @note If permission is already "allow" or "deny", does nothing.
-			 * @note If permission is "ask", shows the permission dialog and updates settings.
-			 * @return bool True if permission was granted (or already granted).
+			 * @brief Asks the operating system for the current notification authorization.
+			 * @return NotificationPermission
 			 */
 			[[nodiscard]]
-			bool requestPermission () const noexcept;
+			NotificationPermission permissionStatus () const noexcept;
+
+			/**
+			 * @brief Asks the operating system to authorize notifications for this application.
+			 * @return NotificationPermission The authorization resulting from the request.
+			 */
+			[[nodiscard]]
+			NotificationPermission requestPermission () const noexcept;
 
 		private:
 
@@ -107,7 +117,6 @@ namespace EmEn
 			/** @copydoc EmEn::ServiceInterface::onTerminate() */
 			bool onTerminate () noexcept override;
 
-			Settings & m_settings; ///< Reference to application settings.
 			Window & m_window; ///< Reference to the parent window.
 	};
 }


### PR DESCRIPTION
## Objectif de la PR :
- Déléguer l'autorisation des notifications système au système d'exploitation : le moteur ne persiste plus une permission maison dans les settings et n'affiche plus sa propre boîte de dialogue de consentement.

## Résumé des changements :
- Suppression de la clé de réglage `Core/Permissions/Notifications` et de son défaut `"ask"` dans `SettingKeys.hpp`
- Suppression de la boîte de dialogue de consentement maison (`Dialog::Message` Oui/Non) et de l'écriture `"allow"` / `"deny"` en settings
- Ajout de l'énumération `NotificationPermission` (`NotDetermined`, `Granted`, `Denied`) et de l'accesseur `permissionStatus()`
- `show()` arbitre désormais sur `permissionStatus() != Granted` au lieu de comparer des chaînes de settings, et ne déclenche plus de demande implicite
- `SystemNotification` ne dépend plus de `Settings` : le constructeur ne prend plus que la `Window`, le membre `m_settings` disparaît, et `Core` est mis à jour en conséquence
- `permissionStatus()` et `requestPermission()` sont pour l'instant des implémentations neutres (autorisé) avec un TODO explicite pour macOS / `UNUserNotificationCenter` — aucun autre OS ne conditionne l'affichage d'une notification
- Documentation Doxygen mise à jour (la note obsolète référençait la clé `"Notifications/Permission"`)

## Impact possible des changements :
- **Changement d'API publique** : `SystemNotification(Settings &, Window &)` devient `SystemNotification(Window &)` — toute construction hors du moteur doit être adaptée
- Une permission précédemment refusée et persistée (`Core/Permissions/Notifications = "deny"`) n'est plus lue : les notifications repartent autorisées, et la clé devient orpheline dans les `settings.json` existants
- Plus aucune boîte de dialogue de consentement n'est affichée par le moteur au premier envoi d'une notification
- Sur macOS, tant que le TODO `UNUserNotificationCenter` n'est pas traité, le statut est rapporté comme accordé sans interroger le système : `show()` peut retourner `true` alors que la notification est en réalité bloquée par l'OS
- `requestPermission()` reste synchrone alors que `requestAuthorization()` répond de façon asynchrone : sa signature devra évoluer vers un callback lors de l'implémentation macOS
- Le consommateur `app_system` adopte cette API dans la PR jumelle [Mango3D/app_system#359](https://github.com/Mango3D/app_system/pull/359) — les deux doivent être fusionnées de concert

## Jira ticket :
N/A

[changer labels]
