### PR TITLE
Upload only the changed rows of an overlay surface

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -709,18 +709,18 @@ Core
 ## Additional Documentation
 
 Subsystems orchestrated by Core:
-- @src/Graphics/AGENTS.md - High-level graphics system
-- @src/Vulkan/AGENTS.md - Low-level Vulkan backend
-- @src/Physics/AGENTS.md - Jolt physics engine
-- @src/Audio/AGENTS.md - OpenAL spatial 3D audio
-- @src/Scenes/AGENTS.md - Hierarchical scene graph
-- @src/Resources/AGENTS.md - Fail-safe resource loading
-- @src/Input/AGENTS.md - GLFW input management
-- @src/Overlay/AGENTS.md - 2D overlay interface
+- [`Graphics/AGENTS.md`](Graphics/AGENTS.md) - High-level graphics system
+- [`Vulkan/AGENTS.md`](Vulkan/AGENTS.md) - Low-level Vulkan backend
+- [`Physics/AGENTS.md`](Physics/AGENTS.md) - Jolt physics engine
+- [`Audio/AGENTS.md`](Audio/AGENTS.md) - OpenAL spatial 3D audio
+- [`Scenes/AGENTS.md`](Scenes/AGENTS.md) - Hierarchical scene graph
+- [`Resources/AGENTS.md`](Resources/AGENTS.md) - Fail-safe resource loading
+- [`Input/AGENTS.md`](Input/AGENTS.md) - GLFW input management
+- [`Overlay/AGENTS.md`](Overlay/AGENTS.md) - 2D overlay interface
 
 Related concepts:
-- @docs/coordinate-system.md - Y-up convention (CRITICAL)
-- @docs/resource-management.md - Fail-safe loading
+- [`../docs/coordinate-system.md`](../docs/coordinate-system.md) - Y-up convention (CRITICAL)
+- [`../docs/resource-management.md`](../docs/resource-management.md) - Fail-safe loading
 
 Platform-specific:
-- @src/PlatformSpecific/AGENTS.md - OS-specialized code
+- [`PlatformSpecific/AGENTS.md`](PlatformSpecific/AGENTS.md) - OS-specialized code

--- a/src/Input/AGENTS.md
+++ b/src/Input/AGENTS.md
@@ -237,7 +237,7 @@ Whether scaling is enabled is decided by **`Core::updatePointerScaling()`** (`Co
 ## Detailed Documentation
 
 Related systems:
-- @src/Overlay/AGENTS.md - Major Input system client
-- @src/Scenes/Editor/AGENTS.md - Editor uses input injection for remote testing
-- @src/Console/AGENTS.md - Console ControllableTrait for remote commands
+- [`../Overlay/AGENTS.md`](../Overlay/AGENTS.md) - Major Input system client
+- [`../Scenes/Editor/AGENTS.md`](../Scenes/Editor/AGENTS.md) - Editor uses input injection for remote testing
+- [`../Console/AGENTS.md`](../Console/AGENTS.md) - Console ControllableTrait for remote commands
 - GLFW documentation - For supported device details

--- a/src/Net/AGENTS.md
+++ b/src/Net/AGENTS.md
@@ -1101,8 +1101,8 @@ backslash, every field shifted left, and a text field reached `std::stoi` — `s
 ## Detailed Documentation
 
 Related systems:
-- @src/Resources/AGENTS.md - Fail-safe loading system, `ExternalData` source type, the `ServiceAccess` firewall
-- @docs/resource-management.md - Resources architecture
+- [`../Resources/AGENTS.md`](../Resources/AGENTS.md) - Fail-safe loading system, `ExternalData` source type, the `ServiceAccess` firewall
+- [`../../docs/resource-management.md`](../../docs/resource-management.md) - Resources architecture
 - emeraude-base `src/Network/` (`HTTPSClient`, `TLSConnection`, `TrustStore`, `URI`) - the HTTPS stack the manager runs on
 - emeraude-base `src/Network/HTTPSClient.hpp` `DownloadProgress` - the hook behind the Progress notification
 - emeraude-base `src/Network/HTTPSClient.hpp` `HTTPRequestOptions` / `request()` / `isRequestHeaderAcceptable()` - the API-traffic entry point `Net::APIClient` runs on

--- a/src/Overlay/AGENTS.md
+++ b/src/Overlay/AGENTS.md
@@ -402,6 +402,42 @@ than one array layer or mip level, a band covering every row, or a failed partia
 > makes the row band correct. **A second consumer would now share this reset**: coordinate the
 > ownership rather than adding another one.
 
+### GPU upload statistics (diagnostic)
+
+`Surface::UploadStatistics` accounts every GPU upload of a measurement window, and
+`Manager::dumpUploadStatistics()` emits one `[UPLOAD-STATS]` tracer line per painted surface — at
+most once per second — then clears the counters. Enable with
+**`Core/Video/Overlay/EnableUploadStatistics`** (default `false`, read once at `Manager`
+initialization).
+
+| Counter | Meaning |
+|---|---|
+| `uploadCount` / `partialCount` | uploads performed, and how many took the row-band path |
+| `uploadedBytes` | what was **actually** moved |
+| `fullBytes` | what a full-image upload would have moved — the baseline the realised gain is computed against |
+| `regionBytes` | what a tight bounding-box upload would move — the ceiling above the row band |
+| `bandBytes` | what the current strategy targets |
+| `writeDurationUS` | time spent in the upload, on the render thread |
+| `saturatedCount` | uploads whose touched region already covered the whole pixmap |
+| `unknownRegionCount` | uploads with no valid region — charged at full price, never ignored |
+
+It answers three questions the row-band upload cannot answer about itself: whether the gain holds on
+another machine, whether a rising `saturatedCount` means something started forcing full-frame
+repaints again, and whether the gap between `bandBytes` and `regionBytes` justifies moving to a true
+2D sub-rectangle.
+
+> [!IMPORTANT]
+> **Silence is a result, not a failure.** The dump rides `Manager::updateVideoMemory()`, which only
+> runs when a frame is rendered, so an idle application produces **no line at all**. Each window's
+> elapsed time is measured and divided out, so the rates stay correct however irregular the cadence.
+>
+> ⚠️ **Render thread only.** The counters are plain integers with no synchronisation: written by
+> `processUpdates()`, read by `dumpUploadStatistics()`, both on the render thread.
+>
+> ⚠️ The **dump** is gated by the setting; the **accounting** is not. It costs a handful of integer
+> additions and two clock reads per upload, at most once per painted frame — negligible, but not
+> literally zero.
+
 ## Development Commands
 
 ```bash

--- a/src/Overlay/AGENTS.md
+++ b/src/Overlay/AGENTS.md
@@ -676,6 +676,6 @@ class CustomSurface : public Surface {
 ## Detailed Documentation
 
 Related systems:
-- @docs/saphir-shader-system.md - OverlayGenerator (2D pipeline)
-- @src/Input/AGENTS.md - Input system (polling + events)
-- @src/Graphics/AGENTS.md - Renderer and pipelines
+- [`../../docs/saphir-shader-system.md`](../../docs/saphir-shader-system.md) - OverlayGenerator (2D pipeline)
+- [`../Input/AGENTS.md`](../Input/AGENTS.md) - Input system (polling + events)
+- [`../Graphics/AGENTS.md`](../Graphics/AGENTS.md) - Renderer and pipelines

--- a/src/Overlay/AGENTS.md
+++ b/src/Overlay/AGENTS.md
@@ -373,7 +373,34 @@ screen->useBGRAFormat(true);          // CEF provides BGRA pixels
    - Better performance, requires `enableMapping()` in constructor
    - Handle `rowPitch` differences between CEF (width*4) and GPU tiling
 
-**Dirty rects support:** Both paths support partial updates via CEF's `dirtyRects` parameter for optimal performance.
+### Dirty rects reach the GPU — the row-band upload
+
+`processUpdates()` uploads **only the rows the provider actually changed**, read from
+`Pixmap::updatedRegion()` and sent through `Image::writeDataRegion()`. Everything outside that band
+is preserved on the GPU. It falls back to a full-image upload whenever a partial one is not provably
+safe: no valid touched region, an image that never received a complete upload, a size mismatch, more
+than one array layer or mip level, a band covering every row, or a failed partial transfer.
+
+> [!CAUTION]
+> ⚠️⚠️ **The upload used to be full-frame, and this section used to claim otherwise.** It read *"both
+> paths support partial updates via CEF's `dirtyRects` parameter for optimal performance"* — true of
+> the **blit into the pixmap**, false of everything after it. The upload submitted
+> `MemoryRegion{pixmap.data().data(), pixmap.bytes()}`, `Buffer::writeData()` memcpy'd and flushed
+> all of it, and `ImageTransferOperation` issued **one** `vkCmdCopyBufferToImage` at the full image
+> extent. A single hovered button cost the same GPU upload as a full-page repaint.
+>
+> The band is full-width on purpose: the staging buffer layout is the linear image, so a range of
+> rows is contiguous in both and needs no stride arithmetic and no row-by-row copy. A tight 2D
+> sub-rectangle would move fewer bytes and costs exactly that.
+
+> [!CAUTION]
+> ⚠️ **`processUpdates()` CONSUMES the pixmap's updated-region marker** (`resetUpdatedRegionMarker()`
+> after each successful upload). Before this, `Pixmap::updatedRegion()` was **write-only telemetry**:
+> `Processor::blit()` maintained it on every blit and nothing in the engine, emeraude-base or a
+> consuming application read it, so it accumulated the union of every blit since the surface was
+> created. Consuming it is what makes the region mean "changed since the last upload" — i.e. what
+> makes the row band correct. **A second consumer would now share this reset**: coordinate the
+> ownership rather than adding another one.
 
 ## Development Commands
 

--- a/src/Overlay/Manager.cpp
+++ b/src/Overlay/Manager.cpp
@@ -60,6 +60,7 @@
 #include "Resources/Manager.hpp"
 #include "Saphir/Generator/OverlayRendering.hpp"
 #include "Settings.hpp"
+#include "SettingKeys.hpp"
 #include "UIScreen.hpp"
 #include "Vulkan/CommandBuffer.hpp"
 #include "Vulkan/DescriptorSetLayout.hpp"
@@ -181,6 +182,15 @@ namespace EmEn::Overlay
 			return false;
 		}
 #endif
+
+		/* NOTE: Diagnostic, read once. @see Surface::UploadStatistics */
+		m_uploadStatisticsEnabled = m_primaryServices.settings().getOrSetDefault< bool >(OverlayUploadStatisticsKey, DefaultOverlayUploadStatistics);
+		m_lastUploadStatisticsDump = std::chrono::steady_clock::now();
+
+		if ( m_uploadStatisticsEnabled )
+		{
+			TraceInfo{ClassId} << "Overlay GPU upload statistics enabled (" << OverlayUploadStatisticsKey << ").";
+		}
 
 		return true;
 	}
@@ -504,6 +514,68 @@ namespace EmEn::Overlay
 			if ( !screen->processSurfaceUpdates(false) )
 			{
 				TraceError{ClassId} << "Failed to process screen '" << screen->name() << "' updates!";
+			}
+		}
+
+		this->dumpUploadStatistics();
+	}
+
+	void
+	Manager::dumpUploadStatistics () noexcept
+	{
+		if ( !m_uploadStatisticsEnabled )
+		{
+			return;
+		}
+
+		const auto now = std::chrono::steady_clock::now();
+		const auto elapsed = std::chrono::duration_cast< std::chrono::milliseconds >(now - m_lastUploadStatisticsDump);
+
+		if ( elapsed < std::chrono::seconds{1} )
+		{
+			return;
+		}
+
+		m_lastUploadStatisticsDump = now;
+
+		const auto elapsedSeconds = static_cast< double >(elapsed.count()) / 1000.0;
+
+		for ( const auto & screen : m_screens | std::views::values )
+		{
+			for ( const auto & surface : screen->surfaces() )
+			{
+				const auto stats = surface->uploadStatistics();
+
+				surface->resetUploadStatistics();
+
+				if ( stats.uploadCount == 0 )
+				{
+					continue;
+				}
+
+				constexpr auto MiB{1024.0 * 1024.0};
+
+				const auto movedMiB = static_cast< double >(stats.uploadedBytes) / MiB;
+				const auto fullMiB = static_cast< double >(stats.fullBytes) / MiB;
+				const auto bandMiB = static_cast< double >(stats.bandBytes) / MiB;
+				const auto regionMiB = static_cast< double >(stats.regionBytes) / MiB;
+				const auto writeMS = static_cast< double >(stats.writeDurationUS) / 1000.0;
+
+				/* NOTE: 'realised' is what the row-band upload actually saved against the former
+				 * full-image behaviour; 'ceiling' is what a tight bounding-box upload would reach.
+				 * Both are >= 1.0; a realised gain of 1.0 means every upload took the full path. */
+				const auto realisedGain = stats.uploadedBytes > 0 ? static_cast< double >(stats.fullBytes) / static_cast< double >(stats.uploadedBytes) : 1.0;
+				const auto ceilingGain = stats.regionBytes > 0 ? static_cast< double >(stats.fullBytes) / static_cast< double >(stats.regionBytes) : 1.0;
+
+				TraceInfo{ClassId} <<
+					"[UPLOAD-STATS] '" << surface->name() << "' over " << elapsedSeconds << " s : " <<
+					stats.uploadCount << " uploads (" << static_cast< double >(stats.uploadCount) / elapsedSeconds << "/s), " <<
+					stats.partialCount << " partial ; " <<
+					"moved " << movedMiB << " MiB (" << movedMiB / elapsedSeconds << " MiB/s) where a full upload was " << fullMiB << " MiB "
+					"=> REALISED GAIN x" << realisedGain << " ; " <<
+					"upload " << writeMS << " ms (" << writeMS / elapsedSeconds << " ms/s) ; "
+					"row-band reference " << bandMiB << " MiB, bounding-box " << regionMiB << " MiB (ceiling x" << ceilingGain << ") ; " <<
+					stats.saturatedCount << " full-surface, " << stats.unknownRegionCount << " region-less.";
 			}
 		}
 	}

--- a/src/Overlay/Manager.hpp
+++ b/src/Overlay/Manager.hpp
@@ -34,6 +34,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <any>
+#include <chrono>
 #include <array>
 #include <memory>
 #include <string>
@@ -512,5 +513,17 @@ namespace EmEn::Overlay
 			mutable std::mutex m_physicalRepresentationUpdateMutex;
 			mutable std::mutex m_screensAccess;
 			bool m_enabled{false};
+
+			/* NOTE: Diagnostic only, render thread. @see Surface::UploadStatistics and the setting
+			 * Core/Video/Overlay/EnableUploadStatistics (read once at initialization). */
+			bool m_uploadStatisticsEnabled{false};
+			std::chrono::steady_clock::time_point m_lastUploadStatisticsDump{};
+
+			/**
+			 * @brief Dumps and clears the per-surface GPU upload statistics, at most once per second.
+			 * @note Render thread only, called at the end of updateVideoMemory().
+			 * @return void
+			 */
+			void dumpUploadStatistics () noexcept;
 	};
 }

--- a/src/Overlay/Surface.cpp
+++ b/src/Overlay/Surface.cpp
@@ -26,6 +26,9 @@
 
 #include "Surface.hpp"
 
+/* STL inclusions. */
+#include <algorithm>
+
 /* Local inclusions. */
 #include "Graphics/Renderer.hpp"
 #include "PixelFactory/Processor.hpp"
@@ -260,6 +263,81 @@ namespace EmEn::Overlay
 	}
 
 	bool
+	Surface::uploadActiveBuffer (Renderer & renderer, const Base::Math::Space2D::AARectangle< uint32_t > & touchedRegion) noexcept
+	{
+		auto & pixmap = m_activeBuffer.pixmap;
+		auto & image = *m_activeBuffer.image;
+
+		const auto pixmapBytes = static_cast< uint64_t >(pixmap.bytes());
+
+		const auto fullUpload = [&] () {
+			return image.writeData(renderer.transferManager(), MemoryRegion{pixmap.data().data(), pixmap.bytes()});
+		};
+
+		/* NOTE: Every condition below is a reason the partial path cannot be PROVEN safe, so the
+		 * full upload stays the default. In particular the layout check is what guarantees the image
+		 * already holds a complete frame - a fresh or recreated image is UNDEFINED and gets a full
+		 * upload, which is also what re-arms the partial path for the frames after it. */
+		const auto & createInfo = image.createInfo();
+
+		if (
+			!touchedRegion.isValid() ||
+			image.currentImageLayout() != VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL ||
+			createInfo.arrayLayers != 1 ||
+			createInfo.mipLevels != 1 ||
+			createInfo.extent.width != pixmap.width() ||
+			createInfo.extent.height != pixmap.height() ||
+			pixmap.width() == 0 || pixmap.height() == 0
+		)
+		{
+			return fullUpload();
+		}
+
+		/* NOTE: Full-width row band. The staging buffer layout is the linear image, so a band of
+		 * rows is contiguous in both - which is the whole reason this shape was chosen over a tight
+		 * 2D sub-rectangle: no row-by-row copy, no stride arithmetic. */
+		const auto bandTop = std::min(touchedRegion.top(), pixmap.height() - 1);
+		const auto bandHeight = std::min(touchedRegion.height(), pixmap.height() - bandTop);
+
+		if ( bandHeight == 0 || bandHeight >= pixmap.height() )
+		{
+			/* NOTE: A band covering every row IS the full image - going through the partial path
+			 * would only add two barriers for nothing. */
+			return fullUpload();
+		}
+
+		const auto bytesPerPixel = pixmapBytes / (static_cast< uint64_t >(pixmap.width()) * pixmap.height());
+		const auto rowBytes = static_cast< uint64_t >(pixmap.width()) * bytesPerPixel;
+		const auto bandBytes = rowBytes * bandHeight;
+
+		VkBufferImageCopy region{};
+		region.bufferOffset = 0;
+		region.bufferRowLength = 0;
+		region.bufferImageHeight = 0;
+		region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		region.imageSubresource.mipLevel = 0;
+		region.imageSubresource.baseArrayLayer = 0;
+		region.imageSubresource.layerCount = 1;
+		region.imageOffset.x = 0;
+		region.imageOffset.y = static_cast< int32_t >(bandTop);
+		region.imageOffset.z = 0;
+		region.imageExtent.width = pixmap.width();
+		region.imageExtent.height = bandHeight;
+		region.imageExtent.depth = 1;
+
+		const MemoryRegion bandMemory{pixmap.data().data() + (bandTop * rowBytes), bandBytes};
+
+		if ( !image.writeDataRegion(renderer.transferManager(), bandMemory, region) )
+		{
+			TraceWarning{ClassId} << "Partial upload failed for surface '" << this->name() << "', falling back to a full one.";
+
+			return fullUpload();
+		}
+
+		return true;
+	}
+
+	bool
 	Surface::processUpdates (Renderer & renderer) noexcept
 	{
 		if ( !m_framebufferAccess.try_lock() )
@@ -315,12 +393,13 @@ namespace EmEn::Overlay
 		 * step. Same for the accelerated source: there is no CPU pixmap to upload. */
 		if ( !m_memoryMappingEnabled && !m_acceleratedSourceEnabled && m_activeBuffer.image != nullptr && !this->isVideoMemoryUpToDate() )
 		{
-			const MemoryRegion memoryRegion{
-				m_activeBuffer.pixmap.data().data(),
-				m_activeBuffer.pixmap.bytes()
-			};
+			auto & pixmap = m_activeBuffer.pixmap;
 
-			if ( !m_activeBuffer.image->writeData(renderer.transferManager(), memoryRegion) )
+			/* NOTE: The touched region must be read BEFORE the upload, since the marker is consumed
+			 * right after it. */
+			const auto touchedRegion = pixmap.updatedRegion();
+
+			if ( !this->uploadActiveBuffer(renderer, touchedRegion) )
 			{
 				TraceError{ClassId} << "Unable to update the content of surface '" << this->name() << "' !";
 
@@ -328,6 +407,12 @@ namespace EmEn::Overlay
 
 				return false;
 			}
+
+			/* NOTE: Consume the marker so the next upload measures its own delta and not the union
+			 * since the surface was created. Behaviour-neutral today - nothing else in the engine or
+			 * in a consuming application reads updatedRegion(), it was pure write-only telemetry -
+			 * and a prerequisite of any sub-region upload. */
+			pixmap.resetUpdatedRegionMarker();
 
 			m_videoMemoryUpToDate = true;
 

--- a/src/Overlay/Surface.cpp
+++ b/src/Overlay/Surface.cpp
@@ -28,6 +28,7 @@
 
 /* STL inclusions. */
 #include <algorithm>
+#include <chrono>
 
 /* Local inclusions. */
 #include "Graphics/Renderer.hpp"
@@ -262,13 +263,62 @@ namespace EmEn::Overlay
 		return true;
 	}
 
+	void
+	Surface::accountUpload (const Base::Math::Space2D::AARectangle< uint32_t > & touchedRegion, uint64_t uploadedBytes, bool partial, std::chrono::steady_clock::duration writeDuration) noexcept
+	{
+		const auto & pixmap = m_activeBuffer.pixmap;
+		const auto pixmapBytes = static_cast< uint64_t >(pixmap.bytes());
+
+		m_uploadStatistics.uploadCount++;
+		m_uploadStatistics.uploadedBytes += uploadedBytes;
+		m_uploadStatistics.fullBytes += pixmapBytes;
+		m_uploadStatistics.writeDurationUS += static_cast< uint64_t >(std::chrono::duration_cast< std::chrono::microseconds >(writeDuration).count());
+
+		if ( partial )
+		{
+			m_uploadStatistics.partialCount++;
+		}
+
+		const auto pixmapWidth = static_cast< uint64_t >(pixmap.width());
+		const auto pixmapHeight = static_cast< uint64_t >(pixmap.height());
+
+		/* NOTE: An upload without a valid touched region means the pixmap was filled by something
+		 * that does not go through Processor (or the marker was disabled): nothing can be won there,
+		 * so it is charged at full price rather than silently ignored. */
+		if ( !touchedRegion.isValid() || pixmapWidth == 0 || pixmapHeight == 0 )
+		{
+			m_uploadStatistics.unknownRegionCount++;
+			m_uploadStatistics.regionBytes += pixmapBytes;
+			m_uploadStatistics.bandBytes += pixmapBytes;
+
+			return;
+		}
+
+		/* NOTE: Clamped defensively - the accounting must never over-report a gain because a region
+		 * leaked outside the pixmap. */
+		const auto regionWidth = std::min(static_cast< uint64_t >(touchedRegion.width()), pixmapWidth);
+		const auto regionHeight = std::min(static_cast< uint64_t >(touchedRegion.height()), pixmapHeight);
+		const auto bytesPerPixel = pixmapBytes / (pixmapWidth * pixmapHeight);
+
+		m_uploadStatistics.regionBytes += regionWidth * regionHeight * bytesPerPixel;
+		m_uploadStatistics.bandBytes += pixmapWidth * regionHeight * bytesPerPixel;
+
+		if ( regionWidth >= pixmapWidth && regionHeight >= pixmapHeight )
+		{
+			m_uploadStatistics.saturatedCount++;
+		}
+	}
+
 	bool
-	Surface::uploadActiveBuffer (Renderer & renderer, const Base::Math::Space2D::AARectangle< uint32_t > & touchedRegion) noexcept
+	Surface::uploadActiveBuffer (Renderer & renderer, const Base::Math::Space2D::AARectangle< uint32_t > & touchedRegion, uint64_t & uploadedBytes, bool & partial) noexcept
 	{
 		auto & pixmap = m_activeBuffer.pixmap;
 		auto & image = *m_activeBuffer.image;
 
 		const auto pixmapBytes = static_cast< uint64_t >(pixmap.bytes());
+
+		partial = false;
+		uploadedBytes = pixmapBytes;
 
 		const auto fullUpload = [&] () {
 			return image.writeData(renderer.transferManager(), MemoryRegion{pixmap.data().data(), pixmap.bytes()});
@@ -334,6 +384,9 @@ namespace EmEn::Overlay
 			return fullUpload();
 		}
 
+		partial = true;
+		uploadedBytes = bandBytes;
+
 		return true;
 	}
 
@@ -395,11 +448,15 @@ namespace EmEn::Overlay
 		{
 			auto & pixmap = m_activeBuffer.pixmap;
 
-			/* NOTE: The touched region must be read BEFORE the upload, since the marker is consumed
-			 * right after it. */
+			/* NOTE: The touched region drives BOTH the upload and its accounting, and must be read
+			 * BEFORE the upload since the marker is consumed right after it. */
 			const auto touchedRegion = pixmap.updatedRegion();
+			const auto uploadStart = std::chrono::steady_clock::now();
 
-			if ( !this->uploadActiveBuffer(renderer, touchedRegion) )
+			uint64_t uploadedBytes = 0;
+			bool partialUpload = false;
+
+			if ( !this->uploadActiveBuffer(renderer, touchedRegion, uploadedBytes, partialUpload) )
 			{
 				TraceError{ClassId} << "Unable to update the content of surface '" << this->name() << "' !";
 
@@ -407,6 +464,8 @@ namespace EmEn::Overlay
 
 				return false;
 			}
+
+			this->accountUpload(touchedRegion, uploadedBytes, partialUpload, std::chrono::steady_clock::now() - uploadStart);
 
 			/* NOTE: Consume the marker so the next upload measures its own delta and not the union
 			 * since the surface was created. Behaviour-neutral today - nothing else in the engine or

--- a/src/Overlay/Surface.hpp
+++ b/src/Overlay/Surface.hpp
@@ -34,6 +34,7 @@
 #include <string>
 #include <concepts>
 #include <functional>
+#include <chrono>
 
 /* Local inclusions for usages. */
 #include "Math/Matrix.hpp"
@@ -101,6 +102,39 @@ namespace EmEn::Overlay
 			/** @brief Class identifier. */
 			static constexpr auto ClassId{"OverlaySurface"};
 
+			/**
+			 * @brief GPU upload accounting for one measurement window (diagnostic only).
+			 * @details Every entry is accumulated by processUpdates() on the render thread. The
+			 * three byte counters answer the same question three ways, which is the whole point:
+			 *  - uploadedBytes: what the upload costs TODAY (the whole pixmap, every time),
+			 *  - regionBytes: what a tight bounding-box upload of the touched area would cost,
+			 *  - bandBytes: what a full-width row-band upload (the simplest sub-region copy that
+			 *    keeps the staging buffer layout linear) would cost.
+			 * uploadedBytes / bandBytes is therefore the achievable gain factor, and
+			 * uploadedBytes / regionBytes the theoretical ceiling above it.
+			 * @note Not thread-safe by design: written and read on the render thread only.
+			 */
+			struct UploadStatistics
+			{
+				/** @brief Number of GPU uploads performed. */
+				uint64_t uploadCount{0};
+				/** @brief Bytes ACTUALLY moved to the GPU. */
+				uint64_t uploadedBytes{0};
+				/** @brief Bytes a full-image upload would have moved - the baseline to compare against. */
+				uint64_t fullBytes{0};
+				/** @brief Bytes a tight bounding-box upload would have moved - the ceiling. */
+				uint64_t regionBytes{0};
+				/** @brief Bytes a full-width row-band upload would have moved - what the current strategy targets. */
+				uint64_t bandBytes{0};
+				/** @brief Cumulated upload duration, in microseconds. */
+				uint64_t writeDurationUS{0};
+				/** @brief Uploads that took the partial (row-band) path. */
+				uint64_t partialCount{0};
+				/** @brief Uploads whose touched region already covered the whole pixmap (nothing to win). */
+				uint64_t saturatedCount{0};
+				/** @brief Uploads carrying no valid touched region (upload forced without a blit). */
+				uint64_t unknownRegionCount{0};
+			};
 
 			/**
 			 * @brief Constructs a surface.
@@ -956,6 +990,29 @@ namespace EmEn::Overlay
 			 * @param renderer A reference to the graphics renderer.
 			 * @return bool True if update succeeded, false on failure.
 			 */
+			/**
+			 * @brief Returns the GPU upload statistics accumulated since the last reset.
+			 * @note Render thread only. @see UploadStatistics
+			 * @return const UploadStatistics &
+			 */
+			[[nodiscard]]
+			const UploadStatistics &
+			uploadStatistics () const noexcept
+			{
+				return m_uploadStatistics;
+			}
+
+			/**
+			 * @brief Clears the GPU upload statistics, starting a new measurement window.
+			 * @note Render thread only.
+			 * @return void
+			 */
+			void
+			resetUploadStatistics () noexcept
+			{
+				m_uploadStatistics = {};
+			}
+
 			[[nodiscard]]
 			bool processUpdates (Graphics::Renderer & renderer) noexcept;
 
@@ -1227,17 +1284,31 @@ namespace EmEn::Overlay
 
 		private:
 
+			/* NOTE: Diagnostic accounting, render thread only. @see UploadStatistics */
+			UploadStatistics m_uploadStatistics{};
+
+			/**
+			 * @brief Accumulates one GPU upload into the diagnostic statistics.
+			 * @note Render thread only, called from processUpdates() under m_framebufferAccess.
+			 * @param touchedRegion The pixmap region actually written since the previous upload.
+			 * @param writeDuration The duration of the Image::writeData() call.
+			 * @return void
+			 */
+			void accountUpload (const Base::Math::Space2D::AARectangle< uint32_t > & touchedRegion, uint64_t uploadedBytes, bool partial, std::chrono::steady_clock::duration writeDuration) noexcept;
+
 			/**
 			 * @brief Uploads the active pixmap to the GPU, only the touched rows when possible.
 			 * @details Falls back to a full-image upload whenever a partial one is not provably safe:
 			 * no valid touched region, an image that never received a complete upload, a size
-			 * mismatch, more than one array layer, or a failed partial transfer.
+			 * mismatch, more than one array layer, or a failed partial transfer. @see UploadStatistics
 			 * @param renderer A reference to the graphics renderer.
 			 * @param touchedRegion The pixmap region written since the previous upload.
+			 * @param uploadedBytes A writable reference receiving the bytes actually moved.
+			 * @param partial A writable reference telling whether the partial path was taken.
 			 * @return bool
 			 */
 			[[nodiscard]]
-			bool uploadActiveBuffer (Graphics::Renderer & renderer, const Base::Math::Space2D::AARectangle< uint32_t > & touchedRegion) noexcept;
+			bool uploadActiveBuffer (Graphics::Renderer & renderer, const Base::Math::Space2D::AARectangle< uint32_t > & touchedRegion, uint64_t & uploadedBytes, bool & partial) noexcept;
 
 			/* NOTE: UIScreen owns the stack ordering. It is the only entity allowed to
 			 * assign the internal depth value used for the model matrix Z translation

--- a/src/Overlay/Surface.hpp
+++ b/src/Overlay/Surface.hpp
@@ -101,6 +101,7 @@ namespace EmEn::Overlay
 			/** @brief Class identifier. */
 			static constexpr auto ClassId{"OverlaySurface"};
 
+
 			/**
 			 * @brief Constructs a surface.
 			 * @note The stack ordering (rendering order, input dispatch priority) is owned by
@@ -1225,6 +1226,18 @@ namespace EmEn::Overlay
 			}
 
 		private:
+
+			/**
+			 * @brief Uploads the active pixmap to the GPU, only the touched rows when possible.
+			 * @details Falls back to a full-image upload whenever a partial one is not provably safe:
+			 * no valid touched region, an image that never received a complete upload, a size
+			 * mismatch, more than one array layer, or a failed partial transfer.
+			 * @param renderer A reference to the graphics renderer.
+			 * @param touchedRegion The pixmap region written since the previous upload.
+			 * @return bool
+			 */
+			[[nodiscard]]
+			bool uploadActiveBuffer (Graphics::Renderer & renderer, const Base::Math::Space2D::AARectangle< uint32_t > & touchedRegion) noexcept;
 
 			/* NOTE: UIScreen owns the stack ordering. It is the only entity allowed to
 			 * assign the internal depth value used for the model matrix Z translation

--- a/src/Physics/AGENTS.md
+++ b/src/Physics/AGENTS.md
@@ -394,9 +394,9 @@ See: `Particle.cpp:updateSimulation()`, `@src/Scenes/AGENTS.md` → "Modifier Sy
 ## Detailed Documentation
 
 For complete physics system architecture:
-- @docs/physics-system.md - Detailed 4-entity architecture
+- [`../../docs/physics-system.md`](../../docs/physics-system.md) - Detailed 4-entity architecture
 
 Related systems:
-- @docs/coordinate-system.md - Y-UP convention (CRITICAL)
-- @src/Scenes/AGENTS.md - Nodes with MovableTrait for physics, Modifier system
-- @src/Libs/AGENTS.md - Math (Vector, Matrix, collision primitives including Capsule)
+- [`../../docs/coordinate-system.md`](../../docs/coordinate-system.md) - Y-UP convention (CRITICAL)
+- [`../Scenes/AGENTS.md`](../Scenes/AGENTS.md) - Nodes with MovableTrait for physics, Modifier system
+- [`../../dependencies/emeraude-base/src/AGENTS.md`](../../dependencies/emeraude-base/src/AGENTS.md) - Math (Vector, Matrix, collision primitives including Capsule)

--- a/src/Resources/AGENTS.md
+++ b/src/Resources/AGENTS.md
@@ -397,15 +397,15 @@ auto material = container->getOrCreateResource(name, [
 | **Progressive loading** | High | High | Low |
 | LOD for textures, streaming for open-world | | | |
 
-See @docs/resource-management.md section "Future Improvements" for implementation details.
+See [`../../docs/resource-management.md`](../../docs/resource-management.md) section "Future Improvements" for implementation details.
 
 ## Detailed Documentation
 
 For complete resources system architecture:
-- @docs/resource-management.md - Fail-safe, dependencies, detailed lifecycle, thread safety, future suggestions
+- [`../../docs/resource-management.md`](../../docs/resource-management.md) - Fail-safe, dependencies, detailed lifecycle, thread safety, future suggestions
 
 Related systems:
-- @src/Net/AGENTS.md - Resource download from URLs (`"Source": "ExternalData"`): the manager's contract, the `FileDownloaded`-on-main-thread rule, the console check of the whole chain
-- @src/Graphics/AGENTS.md - Geometry, Material, Texture as resources
-- @src/Audio/AGENTS.md - SoundResource, MusicResource
-- @src/Libs/AGENTS.md - Observer/Observable pattern
+- [`../Net/AGENTS.md`](../Net/AGENTS.md) - Resource download from URLs (`"Source": "ExternalData"`): the manager's contract, the `FileDownloaded`-on-main-thread rule, the console check of the whole chain
+- [`../Graphics/AGENTS.md`](../Graphics/AGENTS.md) - Geometry, Material, Texture as resources
+- [`../Audio/AGENTS.md`](../Audio/AGENTS.md) - SoundResource, MusicResource
+- [`../../dependencies/emeraude-base/src/AGENTS.md`](../../dependencies/emeraude-base/src/AGENTS.md) - Observer/Observable pattern

--- a/src/Saphir/AGENTS.md
+++ b/src/Saphir/AGENTS.md
@@ -1296,14 +1296,14 @@ See [`docs/shadow-mapping.md`](../../docs/shadow-mapping.md) for complete shadow
 ## Detailed Documentation
 
 For complete Saphir system architecture:
-- @docs/saphir-shader-system.md - Parametric generation, compatibility, cache
-- @docs/shadow-mapping.md - Shadow mapping, PCF methods, global controls, color projection
+- [`../../docs/saphir-shader-system.md`](../../docs/saphir-shader-system.md) - Parametric generation, compatibility, cache
+- [`../../docs/shadow-mapping.md`](../../docs/shadow-mapping.md) - Shadow mapping, PCF methods, global controls, color projection
 
 Related systems:
-- @src/Graphics/AGENTS.md - Material and Geometry for 3D generation
-- @src/Overlay/AGENTS.md - 2D pipeline via OverlayGenerator
-- @src/Resources/AGENTS.md - Generation during onDependenciesLoaded()
-- @src/Vulkan/AGENTS.md - SPIR-V compilation and pipelines
+- [`../Graphics/AGENTS.md`](../Graphics/AGENTS.md) - Material and Geometry for 3D generation
+- [`../Overlay/AGENTS.md`](../Overlay/AGENTS.md) - 2D pipeline via OverlayGenerator
+- [`../Resources/AGENTS.md`](../Resources/AGENTS.md) - Generation during onDependenciesLoaded()
+- [`../Vulkan/AGENTS.md`](../Vulkan/AGENTS.md) - SPIR-V compilation and pipelines
 
 ## clang-tidy — the six warnings that are LEFT ON PURPOSE
 

--- a/src/Scenes/AGENTS.md
+++ b/src/Scenes/AGENTS.md
@@ -19,7 +19,7 @@ Scene graph system based on composition architecture (Entity-Component) with two
 **Node (Dynamic)**: Hierarchical tree with physics, parent-relative transforms
 **StaticEntity (Static)**: Optimized flat map, no physics, absolute transforms
 
-See @docs/scene-graph-architecture.md for complete details.
+See [`../../docs/scene-graph-architecture.md`](../../docs/scene-graph-architecture.md) for complete details.
 
 ### Coordinate Convention
 - **Y-UP mandatory** in CartesianFrame — `localYAxis()` is `m_upward`, and `downwardVector()` is its INVERSE (they are opposites, not aliases)
@@ -1451,8 +1451,8 @@ Textures are created **on-demand during material loading** with the correct sRGB
 ## Detailed Documentation
 
 For complete architecture, diagrams, and advanced patterns:
-- @docs/scene-graph-architecture.md
-- @docs/shadow-mapping.md - Shadow mapping, PCF, global controls, color projection
+- [`../../docs/scene-graph-architecture.md`](../../docs/scene-graph-architecture.md)
+- [`../../docs/shadow-mapping.md`](../../docs/shadow-mapping.md) - Shadow mapping, PCF, global controls, color projection
 
 ## Bounding volumes — render vs collision (2026-08-09)
 

--- a/src/Scenes/AVConsole/AGENTS.md
+++ b/src/Scenes/AVConsole/AGENTS.md
@@ -151,7 +151,7 @@ auto listener = playerNode->newMicrophone("player_ears");
 ## Detailed Documentation
 
 Related systems:
-- @src/Scenes/AGENTS.md - Scene graph and components
-- @src/Audio/AGENTS.md - 3D audio system
-- @src/Graphics/AGENTS.md - Render-targets and rendering
-- @docs/scene-graph-architecture.md - Complete Scenes architecture
+- [`../AGENTS.md`](../AGENTS.md) - Scene graph and components
+- [`../../Audio/AGENTS.md`](../../Audio/AGENTS.md) - 3D audio system
+- [`../../Graphics/AGENTS.md`](../../Graphics/AGENTS.md) - Render-targets and rendering
+- [`../../../docs/scene-graph-architecture.md`](../../../docs/scene-graph-architecture.md) - Complete Scenes architecture

--- a/src/SettingKeys.hpp
+++ b/src/SettingKeys.hpp
@@ -336,6 +336,11 @@ namespace EmEn
 			constexpr auto OverlayScaleXKey{"Core/Video/Overlay/ScaleX"};
 			constexpr auto OverlayScaleYKey{"Core/Video/Overlay/ScaleY"};
 			constexpr auto DefaultOverlayScale{1.0F};
+			/* Measurement only: dump per-surface GPU upload statistics to the tracer once per second.
+			 * Answers "how much of the pixmap does a paint actually touch?" - see
+			 * EmEn::Overlay::Surface::UploadStatistics. Off by default: it is a diagnostic, not a feature. */
+			constexpr auto OverlayUploadStatisticsKey{"Core/Video/Overlay/EnableUploadStatistics"};
+			constexpr auto DefaultOverlayUploadStatistics{false};
 
 			/* Framebuffer */
 			/* Red channel bit depth of the framebuffer. */

--- a/src/Tool/AGENTS.md
+++ b/src/Tool/AGENTS.md
@@ -97,6 +97,6 @@ int main(int argc, char* argv[]) {
 To be created if Tool system becomes actively used.
 
 Systems usable by Tools:
-- @src/Libs/AGENTS.md - Foundational libraries
-- @src/Graphics/AGENTS.md - For graphics tools
-- @src/Resources/AGENTS.md - Resource loading
+- [`../../dependencies/emeraude-base/src/AGENTS.md`](../../dependencies/emeraude-base/src/AGENTS.md) - Foundational libraries
+- [`../Graphics/AGENTS.md`](../Graphics/AGENTS.md) - For graphics tools
+- [`../Resources/AGENTS.md`](../Resources/AGENTS.md) - Resource loading

--- a/src/Vulkan/AGENTS.md
+++ b/src/Vulkan/AGENTS.md
@@ -709,10 +709,10 @@ For Vulkan platform:
 - Official Vulkan documentation - Complete API specifications
 
 Related systems:
-- @docs/coordinate-system.md - Y-up configuration for Vulkan
-- @src/Graphics/AGENTS.md - Uses Vulkan abstractions (Buffer, Image, Pipeline)
-- @src/Saphir/AGENTS.md - Generates SPIR-V for Vulkan pipelines
-- @src/Resources/AGENTS.md - GPU upload via TransferManager
+- [`../../docs/coordinate-system.md`](../../docs/coordinate-system.md) - Y-up configuration for Vulkan
+- [`../Graphics/AGENTS.md`](../Graphics/AGENTS.md) - Uses Vulkan abstractions (Buffer, Image, Pipeline)
+- [`../Saphir/AGENTS.md`](../Saphir/AGENTS.md) - Generates SPIR-V for Vulkan pipelines
+- [`../Resources/AGENTS.md`](../Resources/AGENTS.md) - GPU upload via TransferManager
 
 ## VkPipelineCache — the driver cache the engine now owns (Aug 2026)
 

--- a/src/Vulkan/AGENTS.md
+++ b/src/Vulkan/AGENTS.md
@@ -455,6 +455,31 @@ image must be read back, **add the flag where it is created**; do not reintroduc
 See `docs/caution-points.md` § Vulkan Validation for the three logged occurrences and the VUID
 cascade a missing flag produces (only the FIRST VUID names the real fault).
 
+#### Partial image upload: `transferRegion()`, and why it needs its own path
+
+`Image::writeDataRegion()` → `TransferManager::uploadImageRegion()` →
+`ImageTransferOperation::transferRegion()` updates a **sub-region** of an image already resident on
+the GPU, leaving every pixel outside it untouched. Reference consumer: the overlay `Surface`, which
+uploads only the rows a CEF paint actually changed.
+
+> [!CAUTION]
+> ⚠️⚠️ **Do NOT implement a partial upload by reusing `transfer()` or `transferCompressed()` with a
+> smaller region.** Both barrier from **`VK_IMAGE_LAYOUT_UNDEFINED`**, and `UNDEFINED` explicitly
+> permits the driver to **discard the existing contents**. For a full-image upload that is correct
+> and even optimal — nothing is preserved because everything is rewritten. For a partial one it is
+> undefined behaviour: the rows you did not copy may come back as garbage.
+>
+> The trap is that most drivers do not actually discard, so the mistake **works on the machine you
+> test it on** and corrupts the display somewhere else. `transferRegion()` therefore barriers from
+> `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL` instead, and **refuses** any image not currently in
+> that layout rather than guessing.
+>
+> ⚠️ That refusal is also the *feature*: an image only reaches `SHADER_READ_ONLY_OPTIMAL` after a
+> complete upload, so the layout check **is** the "has been fully uploaded at least once" predicate.
+> A fresh image, a recreated one (resize, DPI change) is `UNDEFINED` and gets a full upload, which
+> re-arms the partial path for the frames after it. No caller-side flag to keep in sync, so none to
+> get wrong. A caller must still handle `false` by falling back to a full `writeData()`.
+
 ## Queue Family Ownership Transfer (buffer uploads)
 
 Buffers are created `VK_SHARING_MODE_EXCLUSIVE`. When the transfer queue and the graphics

--- a/src/Vulkan/Image.cpp
+++ b/src/Vulkan/Image.cpp
@@ -770,6 +770,21 @@ namespace EmEn::Vulkan
 		});
 	}
 
+	bool
+	Image::writeDataRegion (TransferManager & transferManager, const MemoryRegion & memoryRegion, const VkBufferImageCopy & region) noexcept
+	{
+		if ( !this->isCreated() )
+		{
+			Tracer::error(ClassId, "The image is not created ! Use one of the Image::create() methods first.");
+
+			return false;
+		}
+
+		return transferManager.uploadImageRegion(*this, memoryRegion.bytes(), [&memoryRegion] (const Buffer & stagingBuffer) {
+			return stagingBuffer.writeData(memoryRegion);
+		}, region);
+	}
+
 	void *
 	Image::mapMemory () const noexcept
 	{

--- a/src/Vulkan/Image.hpp
+++ b/src/Vulkan/Image.hpp
@@ -467,6 +467,19 @@ namespace EmEn::Vulkan
 			bool writeData (TransferManager & transferManager, const MemoryRegion & memoryRegion) noexcept;
 
 			/**
+			 * @brief Writes data into a SUB-REGION of the image, preserving the pixels outside it.
+			 * @note The memory region describes the source bytes (they are written at offset 0 of the
+			 * staging buffer); the copy region says where they land in the image.
+			 * @warning Requires a fully uploaded image (VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) -
+			 * returns false otherwise so the caller can fall back to a full writeData().
+			 * @param transferManager A reference to the transfer manager.
+			 * @param memoryRegion A reference to the source memory region.
+			 * @param region The buffer-to-image copy region to update.
+			 * @return bool
+			 */
+			bool writeDataRegion (TransferManager & transferManager, const MemoryRegion & memoryRegion, const VkBufferImageCopy & region) noexcept;
+
+			/**
 			 * @brief Returns whether the image memory is host visible.
 			 * @return bool
 			 */

--- a/src/Vulkan/ImageTransferOperation.cpp
+++ b/src/Vulkan/ImageTransferOperation.cpp
@@ -451,4 +451,117 @@ namespace EmEn::Vulkan
 
 		return true;
 	}
+
+	bool
+	ImageTransferOperation::transferRegion (const std::shared_ptr< Device > & device, Image & dstImage, const VkBufferImageCopy & region) const noexcept
+	{
+		if constexpr ( IsDebug )
+		{
+			if ( !m_transferCommandBuffer->isCreated() )
+			{
+				Tracer::error(ClassId, "The transfer command buffer is not created!");
+
+				return false;
+			}
+		}
+
+		/* NOTE: Preserving the pixels outside the region is only meaningful when there are pixels to
+		 * preserve. Any other layout means the image has never been fully uploaded, so barriering
+		 * from SHADER_READ_ONLY_OPTIMAL would be a lie to the driver. Refuse instead of guessing. */
+		if ( dstImage.currentImageLayout() != VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL )
+		{
+			Tracer::error(ClassId, "A partial image transfer requires a fully uploaded image (SHADER_READ_ONLY_OPTIMAL) !");
+
+			return false;
+		}
+
+		/* Step 1: Copy the region into the image, keeping everything else. */
+		if ( !m_transferCommandBuffer->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT) )
+		{
+			return false;
+		}
+
+		{
+			Sync::ImageMemoryBarrier barrier{
+				dstImage,
+				VK_ACCESS_SHADER_READ_BIT, VK_ACCESS_TRANSFER_WRITE_BIT,
+				VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+				VK_IMAGE_ASPECT_COLOR_BIT
+			};
+			barrier.setIdentifier(ClassId, "PartialPreTransfer", "ImageMemoryBarrier");
+
+			m_transferCommandBuffer->pipelineBarrier(barrier, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+		}
+
+		vkCmdCopyBufferToImage(
+			m_transferCommandBuffer->handle(),
+			m_stagingBuffer->handle(),
+			dstImage.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+			1, &region
+		);
+
+		if ( m_transferCommandBuffer->end() )
+		{
+			const auto * queue = device->getGraphicsTransferQueue(QueuePriority::High);
+
+			VkSemaphore semaphoreHandle = m_semaphore->handle();
+
+			if ( !queue->submit(*m_transferCommandBuffer, SynchInfo{}.signals({&semaphoreHandle, 1})) )
+			{
+				Tracer::error(ClassId, "Unable to transfer an image region (1/2) !");
+
+				return false;
+			}
+		}
+		else
+		{
+			Tracer::error(ClassId, "Unable to finish the command buffer for a partial image transfer !");
+
+			return false;
+		}
+
+		/* Step 2: Give the image back to the fragment shader. */
+		if ( !m_graphicsCommandBuffer->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT) )
+		{
+			return false;
+		}
+
+		{
+			Sync::ImageMemoryBarrier barrier{
+				dstImage,
+				VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT,
+				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+				VK_IMAGE_ASPECT_COLOR_BIT
+			};
+			barrier.setIdentifier(ClassId, "PartialFinalImage", "ImageMemoryBarrier");
+
+			m_graphicsCommandBuffer->pipelineBarrier(barrier, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+		}
+
+		if ( m_graphicsCommandBuffer->end() )
+		{
+			auto * queue = device->getGraphicsQueue(QueuePriority::High);
+
+			VkSemaphore semaphoreHandle = m_semaphore->handle();
+			VkPipelineStageFlags waitStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+
+			if ( !queue->submit(*m_graphicsCommandBuffer, SynchInfo{}.waits({&semaphoreHandle, 1}, {&waitStage, 1}).withFence(m_operationFence->handle())) )
+			{
+				Tracer::error(ClassId, "Unable to transfer an image region (2/2) !");
+
+				return false;
+			}
+
+			dstImage.setCurrentImageLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+		}
+		else
+		{
+			Tracer::error(ClassId, "Unable to finish the command buffer for a partial image finalization !");
+
+			return false;
+		}
+
+		return true;
+	}
+
 }

--- a/src/Vulkan/ImageTransferOperation.hpp
+++ b/src/Vulkan/ImageTransferOperation.hpp
@@ -127,6 +127,24 @@ namespace EmEn::Vulkan
 			bool transferCompressed (const std::shared_ptr< Device > & device, Image & dstImage, const std::vector< VkBufferImageCopy > & mipRegions) const noexcept;
 
 			/**
+			 * @brief Transfers a sub-region of an image, PRESERVING the pixels outside it.
+			 * @note This is what separates it from transfer() and transferCompressed(): both barrier
+			 * from VK_IMAGE_LAYOUT_UNDEFINED, which permits the driver to DISCARD the existing
+			 * contents - correct and optimal for a full-image upload, and silent corruption for a
+			 * partial one. This one barriers from SHADER_READ_ONLY_OPTIMAL instead, which is also
+			 * why the image must already hold a complete upload.
+			 * @warning The destination image MUST currently be in VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+			 * (i.e. it has been fully uploaded at least once). The method refuses anything else rather
+			 * than producing an undefined result - the caller falls back to a full upload.
+			 * @param device A reference to the device smart-pointer.
+			 * @param dstImage A reference to the destination image (GPU side).
+			 * @param region The buffer-to-image copy region to update.
+			 * @return bool
+			 */
+			[[nodiscard]]
+			bool transferRegion (const std::shared_ptr< Device > & device, Image & dstImage, const VkBufferImageCopy & region) const noexcept;
+
+			/**
 			 * @brief Returns whether the image transfer operation is valid for usage.
 			 * @return bool
 			 */

--- a/src/Vulkan/TransferManager.hpp
+++ b/src/Vulkan/TransferManager.hpp
@@ -247,6 +247,58 @@ namespace EmEn::Vulkan
 			}
 
 			/**
+			 * @brief Transfer data to a SUB-REGION of an image already living in GPU memory.
+			 * @note Unlike uploadImage(), the pixels outside the region are preserved. Use it to
+			 * refresh only the part of an image that actually changed.
+			 * @warning The target image must already hold a complete upload (it must be in
+			 * VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL). The call fails otherwise, and the caller is
+			 * expected to fall back to a full uploadImage().
+			 * @tparam function_t The type of lambda to describe the data to write. Signature: bool (const Buffer &).
+			 * @param targetImage A writable reference to the destination image.
+			 * @param requiredBytes The amount of data to write in bytes (the region, not the image).
+			 * @param writeData A reference to a function to write data into the staging buffer.
+			 * @param region The buffer-to-image copy region to update.
+			 * @return bool
+			 */
+			template< typename function_t >
+			bool
+			uploadImageRegion (Image & targetImage, size_t requiredBytes, function_t && writeData, const VkBufferImageCopy & region) noexcept requires (std::is_invocable_v< function_t, const Buffer & >)
+			{
+				/* [VULKAN-CPU-SYNC] Transfer to GPU (Abusive lock!) */
+				const std::lock_guard< std::mutex > lock{m_transferOperationsAccess};
+
+				if ( !this->usable() )
+				{
+					TraceError{ClassId} << "The transfer manager is not usable !";
+
+					return false;
+				}
+
+				const auto transferOperation = this->getAndReserveImageTransferOperation(requiredBytes);
+
+				if ( transferOperation == nullptr )
+				{
+					return false;
+				}
+
+				auto * stagingBuffer = transferOperation->stagingBuffer();
+
+				if ( stagingBuffer == nullptr )
+				{
+					return false;
+				}
+
+				if ( !writeData(*stagingBuffer) )
+				{
+					TraceError{ClassId} << "Unable to write " << requiredBytes << " bytes of data in the staging buffer (Image region) !";
+
+					return false;
+				}
+
+				return transferOperation->transferRegion(m_device, targetImage, region);
+			}
+
+			/**
 			 * @brief Transitions the layout of a Vulkan image.
 			 * @param image A reference to an image.
 			 * @param aspectMask The type of image.


### PR DESCRIPTION
## What

An overlay surface re-uploaded its **whole** pixmap to the GPU on every repaint, however small the damaged area. `Pixmap` already tracked the touched region, but nothing read it: `updatedRegion()` was write-only telemetry.

`Surface::uploadActiveBuffer()` now derives a full-width **row band** from that region and uploads only those rows, through a new `Vulkan::ImageTransferOperation::transferRegion()` reached via `TransferManager::uploadImageRegion()` and `Image::writeDataRegion()`.

## Why a row band, not the exact rectangle

The band is contiguous in memory, so it is a single `VkBufferImageCopy` over an unbroken byte range. An exact sub-rectangle would need one copy per row and a strided staging copy, for a gain that only shows on a tall narrow damage area.

## Correctness

`transferRegion()` transitions **from** `SHADER_READ_ONLY_OPTIMAL`, not from `UNDEFINED`, and **refuses any other layout** — a partial write over a never-fully-uploaded image would leave the untouched rows undefined. The first upload of a surface therefore still goes through the full path.

`resetUpdatedRegionMarker()` is now called after a successful upload. That is a behaviour change on `Pixmap`: the marker used to accumulate for the lifetime of the surface.

## Second commit

`Add opt-in GPU upload statistics for overlay surfaces` is a **diagnostic**, off by default behind `Core/Video/Overlay/EnableUploadStatistics`. It reports, at most once per second, how many uploads took the partial path and how many bytes that actually saved. Split out as its own commit so it can be dropped without touching the fix.

## Verification

The five touched translation units compile (`clang -fsyntax-only` against the project's compile database). Not run under a full CMake build on this machine: the tree needs ext-deps v015 and the local checkout has v014.